### PR TITLE
Proxy Authentication

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+      {
+        "source": "/__/auth/:path*",
+        "destination": "https://trusty-drive-408502.firebaseapp.com/__/auth/:path*"
+      }
+    ]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,12 @@ export default defineConfig({
         server: {
             fs: {
                 allow: ['localPackages/firebase-ssr/browser']
-            }
+            },
+            proxy: {
+                '/__/auth': {
+                  target: 'https://reverie-demo.firebaseapp.com',
+                  changeOrigin: true
+                }
+              },
         },
 });


### PR DESCRIPTION
This should fix the issue with authentication not working in Safari / iOS. It should also future-proof the app for upcoming browser changes that will block cross-site cookie authentication.

The first link below is the steps I followed - I've already made the changes within cloud console to support the new OAuth domain.

References:
https://www.echowalk.com/blog/svelte-firebase-reverse-proxy-auth-solution
https://www.reddit.com/r/sveltejs/comments/18y3bw0/sveltekit_and_the_thirdparty_cookie_auth_changes/
https://firebase.google.com/docs/auth/web/redirect-best-practices
https://github.com/firebase/firebaseui-web/issues/945