### PR TITLE
Fixing the default quantity bug

### DIFF
--- a/src/lib/CreateButton.svelte
+++ b/src/lib/CreateButton.svelte
@@ -18,6 +18,7 @@
 	export let data: (text: string, id?: string) => Object = (name) => ({ name });
 	export let color = 'primary';
 	export let buttonText = 'Create New';
+	export let afterCreate: (id: string | null) => Promise<any> = null;
 
 	let text = '';
 	let submitting = false;
@@ -41,7 +42,15 @@
 			}
 
 			return createPromise
-				.then((id) => {
+				.then(async (id) => {
+					try {
+						if (afterCreate) {
+							await afterCreate(id);
+						}
+					} catch (err) {
+						console.error('afterCreate failed', err);
+					}
+
 					clear();
 					dispatch('create', id);
 				})

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -60,8 +60,12 @@ export const handleSignIn = async (userCredential: UserCredential) => {
 		return user
 			.getIdToken(true)
 			.then(setToken)
-			.then(() => (window.location.href = '/home'));
+			.then(() => (window.location.href = '/home'))
+			.catch((ex) => {
+				console.error('Error during sign-in token exchange:', ex);
+			});
 	}
+	return Promise.resolve();
 };
 
 export const signOut = () => {

--- a/src/routes/admin/games/[gameID]/assets/+page.svelte
+++ b/src/routes/admin/games/[gameID]/assets/+page.svelte
@@ -139,28 +139,6 @@
 	};
 
 	let closeModal;
-
-// Snapshot of initial form values taken when the editor opens.
-// This prevents reactive changes (locks, etc.) from re-setting the
-// form while the user is editing and causing fields like
-// `claimLimit` to revert to the stored value (often zero).
-let formInitial: { asset?: any; lock?: any } | null = null;
-
-$: if (editing && formInitial == null) {
-	// take a deep copy so later updates to `editing`/`lock` don't mutate
-	formInitial = {
-		asset: JSON.parse(JSON.stringify(editing.asset?.data ?? {})),
-		lock: JSON.parse(JSON.stringify(lock?.data ?? {}))
-	};
-
-	// If there's no claimLimit stored, default to string "0" so the
-	// input shows zero but we don't overwrite user's edits repeatedly.
-	if (formInitial.lock.claimLimit == null) {
-		formInitial.lock.claimLimit = '0';
-	}
-} else if (!editing) {
-	formInitial = null;
-}
 </script>
 
 <svelte:head>
@@ -185,7 +163,7 @@ $: if (editing && formInitial == null) {
 
 		<Form
 			class="flex flex-column g2"
-			initialValues={formInitial ?? undefined}
+			initialValues={{ asset: editing.asset?.data, lock: lock?.data }}
 			multiform
 			onSubmit={updateAsset}
 			afterSubmit={closeModal}
@@ -310,6 +288,7 @@ $: if (editing && formInitial == null) {
 													name: t,
 													summary: ''
 												})}
+												afterCreate={(id) => (id ? database.locks.doc(id).update({ claimLimit: 0 }) : Promise.resolve())}
 											/>
 										</div>
 									</div>
@@ -324,6 +303,7 @@ $: if (editing && formInitial == null) {
 							parent={assets}
 							id={() => null}
 							data={(t) => ({ type: type.id, name: t, summary: '' })}
+							afterCreate={(id) => (id ? database.locks.doc(id).update({ claimLimit: 0 }) : Promise.resolve())}
 						/>
 					</div>
 				</div>

--- a/src/routes/admin/games/[gameID]/assets/+page.svelte
+++ b/src/routes/admin/games/[gameID]/assets/+page.svelte
@@ -139,6 +139,28 @@
 	};
 
 	let closeModal;
+
+// Snapshot of initial form values taken when the editor opens.
+// This prevents reactive changes (locks, etc.) from re-setting the
+// form while the user is editing and causing fields like
+// `claimLimit` to revert to the stored value (often zero).
+let formInitial: { asset?: any; lock?: any } | null = null;
+
+$: if (editing && formInitial == null) {
+	// take a deep copy so later updates to `editing`/`lock` don't mutate
+	formInitial = {
+		asset: JSON.parse(JSON.stringify(editing.asset?.data ?? {})),
+		lock: JSON.parse(JSON.stringify(lock?.data ?? {}))
+	};
+
+	// If there's no claimLimit stored, default to string "0" so the
+	// input shows zero but we don't overwrite user's edits repeatedly.
+	if (formInitial.lock.claimLimit == null) {
+		formInitial.lock.claimLimit = '0';
+	}
+} else if (!editing) {
+	formInitial = null;
+}
 </script>
 
 <svelte:head>
@@ -163,15 +185,7 @@
 
 		<Form
 			class="flex flex-column g2"
-			initialValues={
-				{
-					asset: editing.asset?.data,
-					lock: {
-					...lock?.data,
-					claimLimit: lock?.data?.claimLimit ?? "0"
-					}
-				}
-			}
+			initialValues={formInitial ?? undefined}
 			multiform
 			onSubmit={updateAsset}
 			afterSubmit={closeModal}


### PR DESCRIPTION
#20 attempted to add a default Asset claimLimit of 0 (unlimited) to all newly created assets. However, there was a bug in the approach, such that the "default" value would override the actual value of the lock, causing it to always appear as 0 when editting an asset. (And then overriding the real claimLimit with 0 upon saving the asset.)

This new approach refactors the previous approach. Instead of attempting to create a default value within the UI, I've added an optional method that the CreateButton can call after creating something. This is a more generalized approach that will let us add additional defaults for other data types in the future.

Additionally, there was a bug that only ocurred when loading locally. On sign in, the user would always be redirected to home. If getting the firebase token failed for some reason (such as due to an old cookie and the firebase emulator having been restarted) then the user would get looped forever, constantly being redirected to /home and then instantly bounced back to the login screen, which would then attempt to redirect to /home, repeat. On HDR monitors this is effectively a flashbang attack, so I've fixed that too.