### PR TITLE
Animation Bug Fixes

### DIFF
--- a/src/lib/ui/PageTransition.svelte
+++ b/src/lib/ui/PageTransition.svelte
@@ -1,15 +1,13 @@
-<script>
+<script lang="ts">
 	import { fly } from 'svelte/transition';
-	import { page } from '$app/stores';
-	// import { afterNavigate, beforeNavigate } from '$app/navigation';
-	$: refresh = $page.url.pathname;
 
-	// beforeNavigate(() => console.log('beforeNav'));
-	// afterNavigate(() => console.log('afterNav'));
+	export let data;
 </script>
 
-{#key refresh}
-	<div in:fly|global={{ y: -50, duration: 250, delay: 300 }} out:fly|global={{ y: -50, duration: 250 }}>
+{#key data.url}
+	<div 
+		in:fly|global={{ y: -50, duration: 250, delay: 300 }}
+		out:fly|global={{ y: -50, duration: 250 }} class="transition-page">
 		<slot />
 	</div>
 {/key}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -10,5 +10,5 @@ export const load: LayoutServerLoad = ({ url, locals }) => {
 	} else if (!user) {
 		redirect(302, '/');
 	}
-	return { user: user, decodedToken: decodedToken };
+	return { user: user, decodedToken: decodedToken, url: url.pathname };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,6 +51,7 @@
 		{ text: 'Logout', onClick: signOut }
 	].filter(Boolean);
 
+    export let data;
     let hasLoaded = false;
     onMount(() => {
 		hasLoaded = true;
@@ -67,7 +68,7 @@
 					<FormChecker {userID}></FormChecker>
 				{/if}
 			{/if}
-			<PageTransition>
+			<PageTransition {data}>
 				{#if hasLoaded}
 					<slot></slot>
 				{/if}


### PR DESCRIPTION
A longstanding bug exists in page transition animations. 
The intended behavior is that the old page flies out (upwards) and the new content flies in (from below).
In reality, what was happening is that the new content would appear instantly, then the new content would fly out, then the same content would fly back in.

In addition to looking weird, this causes a bug with any UI elements that have their own animations, such as PurchasedAssetRow and PurchasedRelationshipChooser. Because the new content would be loading out and back in, the inner animations would get stuck, resulting in empty whitespace appearing on the page. The most visible place this whitespace appears is when going from checkout to viewing your character. 

This PR fixes page transitions to follow the pattern established here:
https://joyofcode.xyz/sveltekit-page-transitions

Now the old content flies away and the new content flies in, and no empty whitespace remains.