### PR TITLE
feat(character): use arrows for browse choose actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ node_modules
 yarn.lock
 package-lock.json
 .firebaserc
-.firebaserc copy

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 yarn.lock
 package-lock.json
 .firebaserc
+.firebaserc copy

--- a/src/lib/characters/AssetRow.svelte
+++ b/src/lib/characters/AssetRow.svelte
@@ -135,8 +135,8 @@
 					<Tooltip rich text="Mark '{asset?.data?.name}' as a favorite">
 						<FavoriteIcon assetID={asset?.id ?? null} {gameID}  on:favorited={scrollToSelf} />
 					</Tooltip>
-					<Tooltip rich text="Add '{asset?.data?.name}'">
-						<IconButton icon="add_shopping_cart" on:click={choose} />
+					<Tooltip rich text="Continue with '{asset?.data?.name}'">
+						<IconButton icon="arrow_forward" on:click={choose} />
 					</Tooltip>
 				</div>
 			</span>
@@ -223,8 +223,8 @@
 				<LockIcon {lockStatus} {asset} />
 				{asset?.data?.name}
 				<div class="ml-auto flex items-center g1">
-					<Tooltip rich text="Remove '{asset?.data?.name}'">
-						<IconButton icon="remove_shopping_cart" on:click={unchoose} />
+					<Tooltip rich text="Go back — remove '{asset?.data?.name}'">
+						<IconButton icon="arrow_back" on:click={unchoose} />
 					</Tooltip>
 				</div>
 			</div>

--- a/src/lib/characters/RelationshipChooser.svelte
+++ b/src/lib/characters/RelationshipChooser.svelte
@@ -187,12 +187,12 @@ $: if (
 		<div class="ml-auto flex items-center g1">
 		{#if allowSort}
 			{#if !isChosen}
-				<Tooltip rich text="Add '{selector?.data?.name }'">
-					<IconButton icon="add_shopping_cart" on:click={() => handleChoose(relationshipSelectorID, rankedIds)} />
+				<Tooltip rich text="Continue with '{selector?.data?.name }'">
+					<IconButton icon="arrow_forward" on:click={() => handleChoose(relationshipSelectorID, rankedIds)} />
 				</Tooltip>
 			{:else}
-				<Tooltip rich text="Remove '{selector?.data?.name }'">
-					<IconButton icon="remove_shopping_cart" on:click={unchoose} />
+				<Tooltip rich text="Go back — remove '{selector?.data?.name }'">
+					<IconButton icon="arrow_back" on:click={unchoose} />
 				</Tooltip>
 			{/if}
 		{/if}


### PR DESCRIPTION
Replace shopping cart icons with arrow_forward and arrow_back in AssetRow and RelationshipChooser. Tooltips now describe continuing vs going back.

Also ignore a local .firebaserc copy backup filename.

Made-with: Cursor