### PR TITLE
Printing and Character Viewing enhancements

### DIFF
--- a/src/lib/characters/PurchasedAssetRow.svelte
+++ b/src/lib/characters/PurchasedAssetRow.svelte
@@ -36,7 +36,7 @@
 
 {#if asset && $assetType?.data?.hideOnCharacterSheet !== true}
 	<div class="items-center hover-bg-primary-light p2" out:slide|global>
-		<span class="h3 flex items-center g1">
+		<span class="h3 flex items-center g1 bold asset-name">
 			{#if asset?.data?.image}
 				{#await storage.getDownloadURL(asset.data.image) then url}
 					<div class="image" style="background-image:url({url})" />
@@ -71,5 +71,10 @@
 		width: 50px;
 		border-radius: 50%;
 		border: 1px solid #ccc;
+	}
+	@media print {
+		.asset-name {
+			color: #000 !important;
+		}
 	}
 </style>

--- a/src/lib/characters/PurchasedRelationshipRow.svelte
+++ b/src/lib/characters/PurchasedRelationshipRow.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import { database } from '$lib/database';
+	import type { Docs } from '$lib/database';
+	import RichViewer from '$lib/ui/RichViewer.svelte';
+	import { storage } from '$lib/firebase';
+	import { getFields } from '$lib/database/types/Relationships';
+	import { readable } from 'svelte/store';
+
+	export let relationship: Docs.Relationship | null = null;
+	export let assignedUserIDs: string[] = [];
+	export let getPartnerName: (userID: string) => string = (id) => id;
+	export let namesLoading: boolean = false;
+
+	const safeRelationshipTypes = database.relationshipTypes ?? readable([]);
+
+	const getRelationshipType = (types: Docs.RelationshipType[]) => {
+		const typeId = relationship?.data?.type;
+		return (types ?? []).find((type) => type.id === typeId);
+	};
+
+	const getDisplayFields = (relationship: Docs.Relationship | null, type: Docs.RelationshipType | undefined) => {
+		if (!relationship || !type) return [];
+		return getFields(relationship, type, false).filter((f) => f.text);
+	};
+</script>
+
+{#if relationship}
+	<div class="items-center hover-bg-primary-light p2">
+		<span class="h3 flex items-center g1 bold relationship-name">
+			{#if relationship?.data?.image}
+				{#await storage.getDownloadURL(relationship.data.image) then url}
+					<div class="image" style="background-image:url({url})" />
+				{/await}
+			{/if}
+			{relationship.data.name}
+		</span>
+		{#each getDisplayFields(relationship, getRelationshipType($safeRelationshipTypes)) as { label, text, type }}
+			<div>
+				{#if label}<h4>{label}</h4>{/if}
+				<div class="pl2">
+					{#if type === 'markdown'}
+						<RichViewer value={text} />
+					{:else}
+						{text}
+					{/if}
+				</div>
+			</div>
+		{/each}
+		{#if assignedUserIDs.length > 0}
+			<div class="partners mt1">
+				<span class="">Assigned:</span>
+				<div class="flex flex-wrap g1 mt1">
+					{#if namesLoading}
+						<span class="partner-chip bg-secondary muted">Loading…</span>
+					{:else}
+					{#each [...assignedUserIDs].sort((a, b) => getPartnerName(a).localeCompare(getPartnerName(b))) as userID}
+						<span class="partner-chip bold bg-secondary">{getPartnerName(userID)}</span>
+						{/each}
+					{/if}
+				</div>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.image {
+		background-position: center center;
+		background-size: 70%;
+		background-repeat: no-repeat;
+		height: 50px;
+		width: 50px;
+		border-radius: 50%;
+		border: 1px solid #ccc;
+	}
+	.partner-chip {
+		padding: 0.2rem 0.6rem;
+		border-radius: 12px;
+	}
+	@media print {
+		.partner-chip {
+			color: #000 !important;
+		}
+		.relationship-name {
+			color: #000 !important;
+		}
+	}
+</style>

--- a/src/lib/characters/PurchasedRelationshipSelectorRow.svelte
+++ b/src/lib/characters/PurchasedRelationshipSelectorRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { Docs } from '$lib/database';
     import RelationshipChooser from './RelationshipChooser.svelte';
-    import RelationshipRow from './RelationshipRow.svelte';
+    import PurchasedRelationshipRow from './PurchasedRelationshipRow.svelte';
     import { database } from '$lib/database';
     import { derived, readable, writable } from 'svelte/store';
     import { keyBy } from 'lodash-es';
@@ -56,7 +56,7 @@
 <div>
     {#if !assignment || !assignment.data?.assignedRelationships || assignment.data?.assignedRelationships.length === 0}
         <!-- No assigned relationships: show chooser but disable sorting/moving -->
-        <div class="hover-bg-primary-light p2">
+        <div class="hover-bg-primary-light p2 print-none">
             <RelationshipChooser relationshipSelectorID={selector.id} allowSort={false} enableHelp={enableHelp} {existingRanks}/>
         </div>
     {:else}
@@ -65,32 +65,16 @@
         <div class="divided">
         {#each assignment.data.assignedRelationships as rel}
             {@const relationship = $relationshipsById?.[rel.relationshipID]}
-            <div class="hover-bg-primary-light p2">
-                <RelationshipRow gameID={null} userID={null} user={null} {relationship} />
-                {#if rel.assignedUserIDs?.length}
-                    <div class="partners mt1">
-                        <span class="muted">Assigned:</span>
-                        <div class="flex flex-wrap g1 mt1">
-                            {#if namesLoading}
-                                <span class="partner-chip bg-secondary muted">Loading…</span>
-                            {:else}
-                                {#each [...rel.assignedUserIDs].sort((a, b) => getPartnerName(a).localeCompare(getPartnerName(b))) as userID}
-                                    <span class="partner-chip bg-secondary">{getPartnerName(userID)}</span>
-                                {/each}
-                            {/if}
-                        </div>
-                    </div>
-                {/if}
-            </div>
+            <PurchasedRelationshipRow
+                {relationship}
+                assignedUserIDs={rel.assignedUserIDs ?? []}
+                {getPartnerName}
+                {namesLoading}
+            />
         {/each}
         </div>
     {/if}
 </div>
 
 <style>
-    .partner-chip {
-        padding: 0.2rem 0.6rem;
-        border-radius: 12px;
-        font-weight: 600;
-    }
 </style>

--- a/src/routes/games/[gameID]/character/+page.svelte
+++ b/src/routes/games/[gameID]/character/+page.svelte
@@ -94,7 +94,10 @@
 
 <h2 class="print-only">{$character?.data?.name}</h2>
 {#if $character?.data?.nameLocked}
-	<h2 class="print-none">{$character?.data?.name}</h2>
+	<div class= "flex items-center g2">
+		<h2 class="print-none">{$character?.data?.name}</h2>
+		<IconButton type="button" icon="print" on:click={() => window.print()} />
+	</div>
 {:else if $hasLoaded}
 	<Form
 		class="print-none mt2 mb2 flex g2 items-center"


### PR DESCRIPTION
- Characters with a pre-assigned name now have a print icon as well
- If relationships have not been assigned, the `PurchasedRelationshipSelectorRow` will not print at all, as it's a complex and interactive UI component that only shows one of your ranked relationships at a time, so printing it doesn't make much sense
- Added a new `PurchasedRelationshipRow`
  - This mirrors  `PurchasedAssetRow`, a simplified view of the asset that only shows the parts that are meant to be shown after purchase. 
  - Character assignments have been moved out of the `PurchasedRelationshipSelectorRow` and into the `PurchasedRelationshipRow
- Both PurchasedRelationshipRow and PurchasedAssetRow now have slightly more consistent font weighting and color when printing (for example, the asset name is no longer fainter text than the field names beneath it) 
