### PR TITLE
Adding asset name to checkout error messages

### DIFF
--- a/src/routes/games/[gameID]/checkout/+page.svelte
+++ b/src/routes/games/[gameID]/checkout/+page.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import Decider from '$lib/characters/Decider.svelte';
-	import { derived, type Readable } from 'svelte/store';
+	import { derived, get, type Readable } from 'svelte/store';
 	import { getNotify } from '$lib/ui/Notifications.svelte';
-	import type {LockLimited, LockPrereqs, LockResult } from '../../../api/checkout/secureLock/+server';
+	import type { LockResult } from '../../../api/checkout/secureLock/+server';
+	import { getLockNotificationText } from './lockNotification';
 	import { onMount } from 'svelte';
-	import { isPlayer } from '$lib/permissions';
 	import { page } from '$app/stores';
 	import { database } from '$lib/database';
+	import type { Docs } from '$lib/database';
+	import type { Dictionary } from 'lodash';
+	import { keyBy } from 'lodash-es';
 
 	const gameName: string = $page.data.gameName;
 	const gameID: string = $page.data.gameID;
@@ -16,6 +19,8 @@
 	const sendNotification = getNotify();
 
 	const character = database.characters?.doc(userID);
+
+	const assetsById: Readable<Dictionary<Docs.Asset>>  = derived(database.assets, ($assets) => keyBy($assets, 'id'));
 
 	const chosenAssets: Readable<string[]> = derived(character, ($character) => {
 		return $character?.data?.assets ?? [];
@@ -43,27 +48,16 @@
 			body: JSON.stringify({ assetID, gameID, depth })
 		})
 			.then((res) => res.json())
-			.then((body: LockResult) => {
-				if (body === true) {
-					return true;
-				}
-
-				const isLimited = (body: LockResult): body is LockLimited =>
-					(body as LockLimited)?.limited === true;
-				const isPrereq = (body: LockResult): body is LockPrereqs =>
-					(body as LockPrereqs)?.missingRequiredFlags != null;
-
-				if (isLimited(body)) {
-					sendNotification({ text: 'This item is no longer available.' });
-				} else if (isPrereq(body)) {
-					sendNotification({ text: 'You do not have the required flags to purchase this item.' });
-				} else {
-					sendNotification({ text: 'Unable to purchase this item.' });
-				}
-
-				return false;
-			});
-
+		.then((body: LockResult) => {
+			const assetName = get(assetsById)[assetID]?.data?.name ?? '';
+			const message = getLockNotificationText(body, assetName);
+			if (message === null) {
+				return true;
+			}
+			sendNotification({ text: message });
+			return false;
+		});	
+		
 	const releaseLocks = (assetIDs: string[]): Promise<boolean> =>
 		fetch('/api/checkout/releaseLocks', {
 			method: 'POST',

--- a/src/routes/games/[gameID]/checkout/__tests__/lockNotification.test.ts
+++ b/src/routes/games/[gameID]/checkout/__tests__/lockNotification.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { getLockNotificationText } from '../lockNotification';
+import type { LockLimited, LockPrereqs } from '../../../../api/checkout/secureLock/+server';
+
+describe('getLockNotificationText', () => {
+	it('returns null when the lock succeeded', () => {
+		expect(getLockNotificationText(true, 'Sword of Truth')).toBeNull();
+	});
+
+	it('returns a limited message with the asset name', () => {
+		const body: LockLimited = { limited: true };
+		expect(getLockNotificationText(body, 'Sword of Truth')).toBe(
+			'This item is no longer available: Sword of Truth.'
+		);
+	});
+
+	it('returns a prereq message with the asset name', () => {
+		const body: LockPrereqs = { missingRequiredFlags: ['knight'], extraLimitedFlags: [] };
+		expect(getLockNotificationText(body, 'Shiny Armour')).toBe(
+			'You do not have the required flags to purchase this item: Shiny Armour.'
+		);
+	});
+
+	it('returns a generic failure message with the asset name', () => {
+		expect(getLockNotificationText(false, 'Elixir')).toBe('Unable to purchase this item: Elixir.');
+	});
+
+	it('omits the asset name suffix when asset name is empty', () => {
+		expect(getLockNotificationText(false, '')).toBe('Unable to purchase this item.');
+	});
+
+	it('omits the asset name suffix for limited when name is empty', () => {
+		const body: LockLimited = { limited: true };
+		expect(getLockNotificationText(body, '')).toBe('This item is no longer available.');
+	});
+
+	it('omits the asset name suffix for prereq when name is empty', () => {
+		const body: LockPrereqs = { missingRequiredFlags: ['knight'], extraLimitedFlags: [] };
+		expect(getLockNotificationText(body, '')).toBe(
+			'You do not have the required flags to purchase this item.'
+		);
+	});
+});

--- a/src/routes/games/[gameID]/checkout/lockNotification.ts
+++ b/src/routes/games/[gameID]/checkout/lockNotification.ts
@@ -1,0 +1,25 @@
+import type { LockLimited, LockPrereqs, LockResult } from '../../../api/checkout/secureLock/+server';
+
+const isLimited = (body: LockResult): body is LockLimited =>
+	(body as LockLimited)?.limited === true;
+
+const isPrereq = (body: LockResult): body is LockPrereqs =>
+	(body as LockPrereqs)?.missingRequiredFlags != null;
+
+/**
+ * Returns a user-facing notification message for a failed lock result,
+ * or `null` if the lock succeeded (body === true).
+ */
+export function getLockNotificationText(body: LockResult, assetName: string): string | null {
+	if (body === true) {
+		return null;
+	}
+	const suffix = assetName ? `: ${assetName}` : '';
+	if (isLimited(body)) {
+		return `This item is no longer available${suffix}.`;
+	} else if (isPrereq(body)) {
+		return `You do not have the required flags to purchase this item${suffix}.`;
+	} else {
+		return `Unable to purchase this item${suffix}.`;
+	}
+}


### PR DESCRIPTION
The name of the asset causing a lock error will now be displayed.