### PR TITLE
Add support for partial matchmaking

### DIFF
--- a/src/lib/characters/PurchasedRelationshipRow.svelte
+++ b/src/lib/characters/PurchasedRelationshipRow.svelte
@@ -60,6 +60,8 @@
 					{/if}
 				</div>
 			</div>
+		{:else}
+			<div class="mt1 italic">Assignments pending, check back soon!</div>
 		{/if}
 	</div>
 {/if}

--- a/src/lib/characters/PurchasedRelationshipSelectorRow.svelte
+++ b/src/lib/characters/PurchasedRelationshipSelectorRow.svelte
@@ -54,7 +54,7 @@
 </script>
 
 <div>
-    {#if !assignment || !assignment.data?.assignedRelationships || assignment.data?.assignedRelationships.length === 0}
+    {#if !assignment || !assignment.data?.assignedRelationships || assignment.data?.assignedRelationships.length === 0 || assignment.data.assignedRelationships.some((r) => !r.shared)}
         <!-- No assigned relationships: show chooser but disable sorting/moving -->
         <div class="hover-bg-primary-light p2 print-none">
             <RelationshipChooser relationshipSelectorID={selector.id} allowSort={false} enableHelp={enableHelp} {existingRanks}/>

--- a/src/lib/matching/__tests__/matching.spec.ts
+++ b/src/lib/matching/__tests__/matching.spec.ts
@@ -437,4 +437,114 @@ describe('CapacitatedRankMaximalMatcher', () => {
       expect(result.size).toBe(0);
     });
   });
+
+  describe('fillTuples with existingCandidates', () => {
+    it('backward compat: empty existingCandidates behaves identically to omitting the argument', () => {
+      const m = new CapacitatedRankMaximalMatcher();
+      m.addNode('A1', false, 1); m.addNode('A2', false, 1);
+      m.addNode('P1', true, 1);  m.addNode('P2', true, 1);
+      m.addEdge('A1', 'P1', 1);
+      m.addEdge('A2', 'P2', 1);
+      m.addEdge('A2', 'P1', 2); // A2 is fill candidate for P1
+
+      const matching = m.solve(2);
+
+      const rostersWithout = m.fillTuples(matching, new Map([['P1', 2], ['P2', 2]]));
+      const rostersWith    = m.fillTuples(matching, new Map([['P1', 2], ['P2', 2]]), []);
+
+      expect([...rostersWithout.get('P1')!].sort()).toEqual([...rostersWith.get('P1')!].sort());
+      expect([...rostersWithout.get('P2')!].sort()).toEqual([...rostersWith.get('P2')!].sort());
+    });
+
+    it('fills using an existing candidate when the new-round roster is unbalanced', () => {
+      // Second run: A_new is the only new applicant and gets matched to P1.
+      // P1 has tupleSize=2 → needs 1 fill. No new-round unmatched applicants exist.
+      // A_old ranked P1 at rank-2 in the prior run but was not assigned to it.
+      // fillTuples should draw A_old from existingCandidates to complete the tuple.
+      const m = new CapacitatedRankMaximalMatcher();
+      m.addNode('A_new', false, 1);
+      m.addNode('P1', true, 1); // 1 remaining slot after prior run
+      m.addEdge('A_new', 'P1', 1);
+
+      const matching = m.solve(1);
+      expect(hasMatch(matching, 'A_new', 'P1')).toBe(true);
+
+      const existingCandidates = [{ applicant: 'A_old', post: 'P1', rank: 2 }];
+      const rosters = m.fillTuples(matching, new Map([['P1', 2]]), existingCandidates);
+
+      expect(rosters.get('P1')).toContain('A_new');
+      expect(rosters.get('P1')).toContain('A_old');
+      expect(rosters.get('P1')!.length).toBe(2);
+    });
+
+    it('prefers a lower-ranked (higher preference) candidate regardless of pool origin', () => {
+      // P1 has 1 new matched applicant (A_new). Two fill candidates exist:
+      //   - A_unmatched (new-round, rank-3 to P1 via originalAdj)
+      //   - A_old (existing candidate, rank-1 to P1)
+      // A_old has lower rank number → should be chosen.
+      const m = new CapacitatedRankMaximalMatcher();
+      m.addNode('A_new', false, 1); m.addNode('A_unmatched', false, 1);
+      m.addNode('P1', true, 1);     m.addNode('P2', true, 1);
+      m.addEdge('A_new',       'P1', 1);
+      m.addEdge('A_unmatched', 'P2', 1);
+      m.addEdge('A_unmatched', 'P1', 3); // rank-3 edge — worse than A_old's rank-1
+
+      const matching = m.solve(3);
+      // A_new→P1, A_unmatched→P2
+      expect(matching.size).toBe(2);
+
+      const existingCandidates = [{ applicant: 'A_old', post: 'P1', rank: 1 }];
+      const rosters = m.fillTuples(matching, new Map([['P1', 2]]), existingCandidates);
+
+      const p1Roster = rosters.get('P1')!;
+      expect(p1Roster.length).toBe(2);
+      // A_old (rank-1) should win over A_unmatched (rank-3)
+      expect(p1Roster).toContain('A_new');
+      expect(p1Roster).toContain('A_old');
+      expect(p1Roster).not.toContain('A_unmatched');
+    });
+
+    it('excludes an existing candidate already present in the new-round roster', () => {
+      // A_old was re-matched in the new run and appears in the roster already.
+      // It should not be added a second time from existingCandidates.
+      const m = new CapacitatedRankMaximalMatcher();
+      m.addNode('A_old', false, 1); m.addNode('A_new', false, 1);
+      m.addNode('P1', true, 2);
+      m.addEdge('A_old', 'P1', 1);
+      m.addEdge('A_new', 'P1', 1);
+
+      const matching = m.solve(1);
+      // Both get matched (P1 has capacity 2)
+      expect(matching.size).toBe(2);
+
+      // A_old is also passed as an existing candidate — should be ignored
+      const existingCandidates = [{ applicant: 'A_old', post: 'P1', rank: 1 }];
+      const rosters = m.fillTuples(matching, new Map([['P1', 2]]), existingCandidates);
+
+      // Roster already divides evenly (2 % 2 === 0), no fill needed
+      expect(rosters.get('P1')!.length).toBe(2);
+      // A_old appears exactly once
+      expect(rosters.get('P1')!.filter((a) => a === 'A_old').length).toBe(1);
+    });
+
+    it('does not fill when new-round matched roster already divides evenly', () => {
+      // P1 gets 2 new-round matched applicants with tupleSize=2 — no fill needed
+      // even though an existingCandidate exists.
+      const m = new CapacitatedRankMaximalMatcher();
+      m.addNode('A1', false, 1); m.addNode('A2', false, 1);
+      m.addNode('P1', true, 2);
+      m.addEdge('A1', 'P1', 1);
+      m.addEdge('A2', 'P1', 1);
+
+      const matching = m.solve(1);
+      expect(matching.size).toBe(2);
+
+      const existingCandidates = [{ applicant: 'A_old', post: 'P1', rank: 1 }];
+      const rosters = m.fillTuples(matching, new Map([['P1', 2]]), existingCandidates);
+
+      // 2 % 2 === 0 → no fill, A_old not added
+      expect(rosters.get('P1')!.length).toBe(2);
+      expect(rosters.get('P1')!).not.toContain('A_old');
+    });
+  });
 });

--- a/src/lib/matching/matching.ts
+++ b/src/lib/matching/matching.ts
@@ -195,36 +195,61 @@ export class CapacitatedRankMaximalMatcher {
    * of that post's tuple size by greedily adding the unmatched applicants who
    * ranked the post highest.
    *
-   * Returns a new Map<postId, NodeId[]> of the complete (possibly over-capacity)
-   * rosters per post. Posts that already divide evenly are included unchanged.
+   * Returns a new Map<postId, NodeId[]> of only the new-round members
+   * (matched + filled). The caller is responsible for merging with any
+   * pre-existing rosters from a prior run.
    *
    * @param matching - the Set<Match> returned by solve()
    * @param tupleSizes - per-post tuple size (defaults to 2 for any post not listed)
+   * @param existingCandidates - optional list of already-assigned applicants who
+   *   ranked a post but were NOT assigned to it in the prior run. These are drawn
+   *   from as additional fill candidates when new-round matched applicants don't
+   *   divide evenly into tuples. Pre-existing rosters are guaranteed to already be
+   *   balanced (length % tupleSize === 0), so only the new-round match count
+   *   determines whether filling is needed.
    */
-  fillTuples(matching: Set<Match>, tupleSizes: Map<NodeId, number> = new Map()): Map<NodeId, NodeId[]> {
+  fillTuples(
+    matching: Set<Match>,
+    tupleSizes: Map<NodeId, number> = new Map(),
+    existingCandidates: { applicant: NodeId; post: NodeId; rank: number }[] = []
+  ): Map<NodeId, NodeId[]> {
     // Build initial rosters from the matching
     const rosters = new Map<NodeId, NodeId[]>();
     for (const post of this.posts) rosters.set(post, []);
     for (const { applicant, post } of matching) rosters.get(post)!.push(applicant);
 
-    // Build a lookup: post -> sorted list of (applicant, rank) for unmatched applicants
-    // adj stores edges on both sides, so we read from each post's adjacency list
+    // Index existing candidates by post for fast lookup
+    const existingCandidatesByPost = new Map<NodeId, { applicant: NodeId; rank: number }[]>();
+    for (const { applicant, post, rank } of existingCandidates) {
+      if (!existingCandidatesByPost.has(post)) existingCandidatesByPost.set(post, []);
+      existingCandidatesByPost.get(post)!.push({ applicant, rank });
+    }
+
     for (const post of this.posts) {
       const tupleSize = tupleSizes.get(post) ?? 2;
       const roster = rosters.get(post)!;
+      // Existing rosters are guaranteed balanced (length % tupleSize === 0),
+      // so only the new-round matched count determines whether filling is needed.
       const remainder = roster.length % tupleSize;
       if (remainder === 0) continue;
 
       const needed = tupleSize - remainder;
 
-      // Collect unmatched applicants who have an edge to this post, sorted by rank (ascending)
+      // Pool A: new-round unmatched applicants with an edge to this post
       const candidates: { applicant: NodeId; rank: number }[] = [];
       for (const edge of this.originalAdj.get(post) ?? []) {
         const applicant = edge.to;
         if (!this.applicants.has(applicant)) continue; // skip post-side neighbours
-        if (roster.includes(applicant)) continue;      // already assigned
+        if (roster.includes(applicant)) continue;      // already in new-round roster
         candidates.push({ applicant, rank: edge.rank });
       }
+
+      // Pool B: existing-round applicants who ranked this post but weren't assigned to it
+      for (const { applicant, rank } of existingCandidatesByPost.get(post) ?? []) {
+        if (roster.includes(applicant)) continue; // already in new-round roster
+        candidates.push({ applicant, rank });
+      }
+
       candidates.sort((a, b) => a.rank - b.rank);
 
       for (let i = 0; i < needed && i < candidates.length; i++) {

--- a/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
+++ b/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
@@ -99,6 +99,17 @@
 		).length;
 	};
 
+	// ── Count participants with rankings but no assignment yet ─────────────────
+	const countUnassigned = (selectorID: string): number => {
+		const assignments = $assignmentsBySelectorId[selectorID] ?? [];
+		return assignments.filter(
+			(a) =>
+				Array.isArray(a.data.relationshipRankings) &&
+				a.data.relationshipRankings.length > 0 &&
+				(!Array.isArray(a.data.assignedRelationships) || a.data.assignedRelationships.length === 0)
+		).length;
+	};
+
 	// ── Run the matching algorithm ─────────────────────────────────────────────
 	const runAlgorithm = async (selectorID: string) => {
 		running = { ...running, [selectorID]: true };
@@ -300,6 +311,7 @@
 			{#each $relationshipSelectors as selector (selector.id)}
 				{@const selectorHasAssignments = hasAssignments(selector.id)}
 				{@const rankingCount = countRankings(selector.id)}
+				{@const unassignedCount = countUnassigned(selector.id)}
 				{@const isRunning = running[selector.id]}
 				{@const isClearing = clearing[selector.id]}
 				{@const isExpanded = $expanded[selector.id] ?? false}
@@ -329,17 +341,16 @@
 								<span class="chip bg-success text-on-success">
 									<Icon>check_circle</Icon> Assigned
 								</span>
-							<ConfirmButton on:confirm={() => clearAssignments(selector.id)} />
-							{:else}
+								<ConfirmButton on:confirm={() => clearAssignments(selector.id)} />
+							{/if}
+							{#if unassignedCount > 0}
 								{#if isRunning}
 									<Spinner />
 									<span class="muted">Running…</span>
 								{:else}
-									<Button
-										disabled={rankingCount === 0}
-										on:click={() => runAlgorithm(selector.id)}
-									>
-										<Icon>auto_awesome</Icon> Run Algorithm
+									<Button on:click={() => runAlgorithm(selector.id)}>
+										<Icon>auto_awesome</Icon>
+										{selectorHasAssignments ? 'Run for New Participants' : 'Run Algorithm'}
 									</Button>
 								{/if}
 							{/if}

--- a/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
+++ b/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
@@ -390,31 +390,26 @@
 
 						<div class="flex g1 items-center">
 							{#if selectorHasAssignments}
+								{@const isSelectorSharedNow = isSelectorShared(selector.id)}
 								<span class="chip bg-success text-on-success">
 									<Icon>check_circle</Icon> Assigned
 								</span>
+								{#if sharing[selector.id]}
+									<Spinner />
+								{:else}
+									<button
+										class="share-toggle"
+										class:active={isSelectorSharedNow}
+										title={isSelectorSharedNow ? 'Unshare with participants' : 'Share with participants'}
+										on:click={() => shareRelationships(selector.id, !isSelectorSharedNow)}
+									>
+										<Icon>{isSelectorSharedNow ? 'visibility' : 'visibility_off'}</Icon>
+										{isSelectorSharedNow ? 'Shared' : 'Share with participants'}
+									</button>
+								{/if}
 								<ConfirmButton on:confirm={() => clearAssignments(selector.id)} />
 							{/if}
 							{#if unassignedCount > 0}
-							{@const isSelectorSharedNow = isSelectorShared(selector.id)}
-							<span class="chip bg-success text-on-success">
-								<Icon>check_circle</Icon> Assigned
-							</span>
-							{#if sharing[selector.id]}
-								<Spinner />
-							{:else}
-								<button
-									class="share-toggle"
-									class:active={isSelectorSharedNow}
-									title={isSelectorSharedNow ? 'Unshare with participants' : 'Share with participants'}
-									on:click={() => shareRelationships(selector.id, !isSelectorSharedNow)}
-								>
-									<Icon>{isSelectorSharedNow ? 'visibility' : 'visibility_off'}</Icon>
-									{isSelectorSharedNow ? 'Shared' : 'Share with participants'}
-								</button>
-							{/if}
-							<ConfirmButton on:confirm={() => clearAssignments(selector.id)} />
-							{:else}
 								{#if isRunning}
 									<Spinner />
 									<span class="muted">Running…</span>

--- a/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
+++ b/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
@@ -243,14 +243,15 @@
 					const doc = selectorAssignments.find((a) => a.data.userID === uid);
 					if (!doc) return;
 					const existing = doc.data.assignedRelationships ?? [];
-					let updated: { relationshipID: string; assignedUserIDs: string[] }[];
+					let updated: { relationshipID: string; assignedUserIDs: string[]; shared: boolean }[];
 					if (uid === oldUserID) {
 						// Remove this relationship from the old user's assignments
 						updated = existing.filter((r) => r.relationshipID !== relationshipID);
 					} else {
 						// Add or update this relationship with the new roster for everyone else
 						const others = existing.filter((r) => r.relationshipID !== relationshipID);
-						updated = [...others, { relationshipID, assignedUserIDs: newRoster }];
+						const existingShared = existing.find((r) => r.relationshipID === relationshipID)?.shared ?? false;
+						updated = [...others, { relationshipID, assignedUserIDs: newRoster, shared: existingShared }];
 					}
 					await doc.update({ assignedRelationships: updated });
 				})

--- a/src/routes/api/relationships/assignRelationships/+server.ts
+++ b/src/routes/api/relationships/assignRelationships/+server.ts
@@ -53,86 +53,214 @@ export const POST: RequestHandler = async (event) => {
 		);
 
 		// ── 3. Load all existing assignments for this selector ─────────────────
-		//      We only look at assignments that have rankings but no assignedRelationships yet.
 		const allAssignments: Docs.RelationshipAssignment[] = await database.relationshipAssignments
 			?.withQueries({ field: 'relationshipSelectorID', op: '==', value: relationshipSelectorID })
 			.read() ?? [];
 
-		const assignments = allAssignments.filter(
+		// Split into already-assigned participants and new ones needing matching
+		const alreadyAssigned = allAssignments.filter(
+			(a) =>
+				Array.isArray(a.data.assignedRelationships) &&
+				a.data.assignedRelationships.length > 0
+		);
+		const newAssignments = allAssignments.filter(
 			(a) =>
 				Array.isArray(a.data.relationshipRankings) &&
-				a.data.relationshipRankings.length > 0
+				a.data.relationshipRankings.length > 0 &&
+				(!Array.isArray(a.data.assignedRelationships) || a.data.assignedRelationships.length === 0)
 		);
 
-		if (assignments.length === 0) {
+		// No one has submitted rankings at all
+		const anyWithRankings = allAssignments.some(
+			(a) => Array.isArray(a.data.relationshipRankings) && a.data.relationshipRankings.length > 0
+		);
+		if (!anyWithRankings) {
 			return json({ success: false, message: 'No participants have submitted rankings yet' });
 		}
 
-		// ── 4. Build and run the matcher ────────────────────────────────────────
+		// Everyone who submitted rankings is already assigned
+		if (newAssignments.length === 0) {
+			return json({ success: true, assignments: 0, message: 'All participants are already assigned' });
+		}
+
+		// ── 4. Build existing roster map from already-assigned docs ────────────
+		// existingRostersByRelID: relID -> set of userIDs already in that relationship
+		const existingRostersByRelID = new Map<string, string[]>();
+		for (const assignment of alreadyAssigned) {
+			for (const ar of assignment.data.assignedRelationships ?? []) {
+				if (!existingRostersByRelID.has(ar.relationshipID)) {
+					existingRostersByRelID.set(ar.relationshipID, []);
+				}
+				const roster = existingRostersByRelID.get(ar.relationshipID)!;
+				if (!roster.includes(assignment.data.userID)) {
+					roster.push(assignment.data.userID);
+				}
+			}
+		}
+
+		// ── 5. Build existingCandidates for fillTuples ─────────────────────────
+		// For each already-assigned user, collect posts they ranked but were NOT assigned to.
+		const existingCandidates: { applicant: string; post: string; rank: number }[] = [];
+		for (const assignment of alreadyAssigned) {
+			const assignedRelIDs = new Set(
+				(assignment.data.assignedRelationships ?? []).map((ar) => ar.relationshipID)
+			);
+			const rankings: string[] = assignment.data.relationshipRankings ?? [];
+			rankings.forEach((relID, index) => {
+				if (relationshipIDs.includes(relID) && !assignedRelIDs.has(relID)) {
+					existingCandidates.push({ applicant: assignment.data.userID, post: relID, rank: index + 1 });
+				}
+			});
+		}
+
+		// ── 6. Build and run the matcher (new participants only) ────────────────
 		const matcher = new CapacitatedRankMaximalMatcher();
 
-		// Shuffle applicants and relationships before adding to eliminate any
-		// ordering bias in the algorithm (e.g. first-listed users always winning).
-		const shuffledAssignments = [...assignments].sort(() => Math.random() - 0.5);
+		const shuffledNewAssignments = [...newAssignments].sort(() => Math.random() - 0.5);
 		const shuffledRelationships = [...relationships].sort(() => Math.random() - 0.5);
 
-		// Add applicant nodes (one per participant)
-		for (const assignment of shuffledAssignments) {
-			const userID = assignment.data.userID;
-			matcher.addNode(userID, false, relationshipsPerCharacter);
+		// Add applicant nodes for new participants only
+		for (const assignment of shuffledNewAssignments) {
+			matcher.addNode(assignment.data.userID, false, relationshipsPerCharacter);
 		}
 
-		// Add post nodes (one per relationship) and edges
+		// Add post nodes with capacity reduced by existing assignments
 		const tupleSizes = new Map<string, number>();
+		const addedPostIDs = new Set<string>();
 		for (const rel of shuffledRelationships) {
-			const capacity = rel.data.capacity > 0 ? rel.data.capacity : assignments.length;
+			const existingCount = existingRostersByRelID.get(rel.id)?.length ?? 0;
+			const baseCapacity = rel.data.capacity > 0 ? rel.data.capacity : allAssignments.length;
+			const remainingCapacity = Math.max(0, baseCapacity - existingCount);
 			const size = rel.data.size ?? 2;
-			matcher.addNode(rel.id, true, capacity);
 			tupleSizes.set(rel.id, size);
+			// Only add as a post node if slots remain — but still track tuple size
+			if (remainingCapacity > 0) {
+				matcher.addNode(rel.id, true, remainingCapacity);
+				addedPostIDs.add(rel.id);
+			}
 		}
 
-		// Add ranked edges: rank 1 = most preferred
-		for (const assignment of shuffledAssignments) {
+		// Add ranked edges from new participants (only to posts that have remaining slots)
+		for (const assignment of shuffledNewAssignments) {
 			const userID = assignment.data.userID;
 			const rankings: string[] = assignment.data.relationshipRankings ?? [];
 			rankings.forEach((relID, index) => {
-				if (relationshipIDs.includes(relID)) {
+				if (addedPostIDs.has(relID)) {
 					matcher.addEdge(userID, relID, index + 1);
 				}
 			});
 		}
 
-		// Determine max rank from rankings length
-		const maxRank = Math.max(...shuffledAssignments.map((a) => a.data.relationshipRankings?.length ?? 0), 1);
+		const maxRank = Math.max(...shuffledNewAssignments.map((a) => a.data.relationshipRankings?.length ?? 0), 1);
 
 		const matching = matcher.solve(maxRank);
-		const rosters = matcher.fillTuples(matching, tupleSizes);
+		// newRosters: Map<relID, newRoundUserIDs[]> — new-round additions only
+		const newRosters = matcher.fillTuples(matching, tupleSizes, existingCandidates);
 
-		// ── 5. Write results to Firestore via batched writes ────────────────────
-		//      rosters is the authoritative source: Map<relID, userID[]>.
-		//      Invert it to get per-user assignments, then write one doc per user.
+		// ── 7. Write results to Firestore via batched writes ────────────────────
+		// Build combined rosters: existing members + new-round additions per relID
+		const combinedRosters = new Map<string, string[]>();
+		for (const rel of relationships) {
+			const existing = existingRostersByRelID.get(rel.id) ?? [];
+			const added = newRosters.get(rel.id) ?? [];
+			combinedRosters.set(rel.id, [...existing, ...added]);
+		}
 
-		// Build per-user assignment list from rosters (includes fillTuples additions)
-		const userAssignments = new Map<string, string[]>();
-		for (const [relID, userIDs] of rosters) {
+		// Determine which relIDs gained new members this run
+		const changedRelIDs = new Set<string>(
+			[...newRosters.entries()]
+				.filter(([, users]) => users.length > 0)
+				.map(([relID]) => relID)
+		);
+
+		// Build per-user assignment list for new participants from combined rosters
+		const newUserAssignments = new Map<string, string[]>();
+		for (const [relID, userIDs] of newRosters) {
 			for (const userID of userIDs) {
-				if (!userAssignments.has(userID)) userAssignments.set(userID, []);
-				userAssignments.get(userID)!.push(relID);
+				// Only track new-round users (not existing fill candidates pulled in)
+				if (newAssignments.some((a) => a.data.userID === userID)) {
+					if (!newUserAssignments.has(userID)) newUserAssignments.set(userID, []);
+					newUserAssignments.get(userID)!.push(relID);
+				}
 			}
 		}
 
-		// Every participant who submitted rankings gets a doc written (even if unmatched)
-		type WriteOp = { path: string; data: { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] } };
-		const ops: WriteOp[] = assignments.map((assignment) => {
+		type WriteOp = {
+			path: string;
+			data: { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] };
+		};
+		const ops: WriteOp[] = [];
+
+		// Write docs for new participants
+		for (const assignment of newAssignments) {
 			const userID = assignment.data.userID;
-			const assignedRelIDs = userAssignments.get(userID) ?? [];
+			const assignedRelIDs = newUserAssignments.get(userID) ?? [];
 			const assignedRelationships = assignedRelIDs.map((relID) => ({
 				relationshipID: relID,
-				assignedUserIDs: rosters.get(relID) ?? []
+				assignedUserIDs: combinedRosters.get(relID) ?? []
 			}));
 			const key = relationshipAssignmentKey(relationshipSelectorID, userID);
-			return { path: `games/${gameID}/relationshipAssignments/${key}`, data: { assignedRelationships } };
-		});
+			ops.push({ path: `games/${gameID}/relationshipAssignments/${key}`, data: { assignedRelationships } });
+		}
+
+		// Patch existing participants' docs for any relationship that gained new members
+		for (const assignment of alreadyAssigned) {
+			const touchedRels = (assignment.data.assignedRelationships ?? []).filter((ar) =>
+				changedRelIDs.has(ar.relationshipID)
+			);
+			if (touchedRels.length === 0) continue;
+
+			// Rebuild assignedRelationships: update assignedUserIDs for changed rels, keep others intact
+			const updatedAssignedRelationships = (assignment.data.assignedRelationships ?? []).map((ar) => {
+				if (changedRelIDs.has(ar.relationshipID)) {
+					return { ...ar, assignedUserIDs: combinedRosters.get(ar.relationshipID) ?? ar.assignedUserIDs };
+				}
+				return ar;
+			});
+			const key = relationshipAssignmentKey(relationshipSelectorID, assignment.data.userID);
+			ops.push({
+				path: `games/${gameID}/relationshipAssignments/${key}`,
+				data: { assignedRelationships: updatedAssignedRelationships }
+			});
+		}
+
+		// Also patch any existing user who was pulled in as a fill candidate this run
+		// (they appear in newRosters but are not in newAssignments)
+		const newParticipantIDs = new Set(newAssignments.map((a) => a.data.userID));
+		const fillFromExisting = new Map<string, string[]>(); // userID -> relIDs they were fill-added to
+		for (const [relID, userIDs] of newRosters) {
+			for (const userID of userIDs) {
+				if (!newParticipantIDs.has(userID)) {
+					// This is an existing user pulled in as a fill candidate
+					if (!fillFromExisting.has(userID)) fillFromExisting.set(userID, []);
+					fillFromExisting.get(userID)!.push(relID);
+				}
+			}
+		}
+		for (const [userID, addedRelIDs] of fillFromExisting) {
+			const existingDoc = alreadyAssigned.find((a) => a.data.userID === userID);
+			if (!existingDoc) continue; // shouldn't happen
+			const existingRels = existingDoc.data.assignedRelationships ?? [];
+			// Merge: update changed rels + append newly fill-added rels
+			const updatedMap = new Map(existingRels.map((ar) => [ar.relationshipID, ar]));
+			for (const relID of addedRelIDs) {
+				updatedMap.set(relID, {
+					relationshipID: relID,
+					assignedUserIDs: combinedRosters.get(relID) ?? []
+				});
+			}
+			// Also update assignedUserIDs for any previously assigned rel that changed
+			for (const [relID, ar] of updatedMap) {
+				if (changedRelIDs.has(relID)) {
+					updatedMap.set(relID, { ...ar, assignedUserIDs: combinedRosters.get(relID) ?? ar.assignedUserIDs });
+				}
+			}
+			const key = relationshipAssignmentKey(relationshipSelectorID, userID);
+			ops.push({
+				path: `games/${gameID}/relationshipAssignments/${key}`,
+				data: { assignedRelationships: [...updatedMap.values()] }
+			});
+		}
 
 		// Commit in chunks of 500 (Firestore batch limit)
 		const BATCH_SIZE = 500;
@@ -145,7 +273,7 @@ export const POST: RequestHandler = async (event) => {
 			await batch.commit();
 		}
 
-		return json({ success: true, assignments: ops.length });
+		return json({ success: true, assignments: newAssignments.length });
 	} catch (err: any) {
 		console.error('assignRelationships error:', err);
 		return json({ success: false, message: (err as Error).message ?? String(err) });

--- a/src/routes/api/relationships/assignRelationships/+server.ts
+++ b/src/routes/api/relationships/assignRelationships/+server.ts
@@ -187,20 +187,17 @@ export const POST: RequestHandler = async (event) => {
 
 		type WriteOp = {
 			path: string;
-			data: { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] };
+			data: { assignedRelationships: { relationshipID: string; assignedUserIDs: string[]; shared: boolean }[] };
 		};
 		const ops: WriteOp[] = [];
 
 		// Write docs for new participants
 		for (const assignment of newAssignments) {
-		// Every participant who submitted rankings gets a doc written (even if unmatched)
-		type WriteOp = { path: string; data: { assignedRelationships: { relationshipID: string; assignedUserIDs: string[]; shared: boolean }[] } };
-		const ops: WriteOp[] = assignments.map((assignment) => {
 			const userID = assignment.data.userID;
 			const assignedRelIDs = newUserAssignments.get(userID) ?? [];
 			const assignedRelationships = assignedRelIDs.map((relID) => ({
 				relationshipID: relID,
-				assignedUserIDs: combinedRosters.get(relID) ?? []
+				assignedUserIDs: combinedRosters.get(relID) ?? [],
 				shared: false
 			}));
 			const key = relationshipAssignmentKey(relationshipSelectorID, userID);
@@ -250,7 +247,8 @@ export const POST: RequestHandler = async (event) => {
 			for (const relID of addedRelIDs) {
 				updatedMap.set(relID, {
 					relationshipID: relID,
-					assignedUserIDs: combinedRosters.get(relID) ?? []
+					assignedUserIDs: combinedRosters.get(relID) ?? [],
+					shared: false
 				});
 			}
 			// Also update assignedUserIDs for any previously assigned rel that changed

--- a/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
+++ b/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
@@ -374,4 +374,251 @@ describe('POST /api/relationships/assignRelationships', () => {
     const writtenPaths = batchOps.map((op) => op.path);
     expect(writtenPaths.every((p) => !p.includes('user-no-rank'))).toBe(true);
   });
+
+  // ── Incremental matchmaking ─────────────────────────────────────────────────
+
+  it('returns success with assignments=0 when all participants are already assigned', async () => {
+    // All docs have non-empty assignedRelationships
+    assignmentDocs = Array.from({ length: 5 }, (_, i) =>
+      makeDoc(`${SELECTOR_ID}-user-${i}`, {
+        userID: `user-${i}`,
+        relationshipSelectorID: SELECTOR_ID,
+        relationshipRankings: shuffle([...relationshipIDs]),
+        assignedRelationships: [{ relationshipID: relationshipIDs[0], assignedUserIDs: [`user-${i}`] }]
+      })
+    );
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignments).toBe(0);
+    expect(batchOps).toHaveLength(0); // nothing to write
+  });
+
+  it('only matchmakes new participants when some are already assigned', async () => {
+    const ASSIGNED_COUNT = 10;
+    const NEW_COUNT = 5;
+
+    // 10 already-assigned participants
+    const alreadyAssignedDocs = Array.from({ length: ASSIGNED_COUNT }, (_, i) =>
+      makeDoc(`${SELECTOR_ID}-existing-${i}`, {
+        userID: `existing-${i}`,
+        relationshipSelectorID: SELECTOR_ID,
+        relationshipRankings: shuffle([...relationshipIDs]),
+        assignedRelationships: [
+          { relationshipID: relationshipIDs[i % NUM_POSTS], assignedUserIDs: [`existing-${i}`, `existing-${(i + 1) % ASSIGNED_COUNT}`] }
+        ]
+      })
+    );
+
+    // 5 new participants with rankings but no assignments
+    const newDocs = Array.from({ length: NEW_COUNT }, (_, i) =>
+      makeDoc(`${SELECTOR_ID}-newuser-${i}`, {
+        userID: `newuser-${i}`,
+        relationshipSelectorID: SELECTOR_ID,
+        relationshipRankings: shuffle([...relationshipIDs]),
+        assignedRelationships: []
+      })
+    );
+
+    assignmentDocs = [...alreadyAssignedDocs, ...newDocs];
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    // assignments count = number of new participants processed
+    expect(body.assignments).toBe(NEW_COUNT);
+
+    // All written paths involve newuser- or existing- (existing patched if their rel changed)
+    const newUserPaths = batchOps.map((op) => op.path).filter((p) => p.includes('newuser-'));
+    expect(newUserPaths.length).toBe(NEW_COUNT);
+  });
+
+  it('reduces post capacity by the number of already-assigned users', async () => {
+    // rel-0 has capacity 2 and is already full (2 existing users)
+    const fullRelID = 'rel-0';
+
+    const alreadyAssignedDocs = [
+      makeDoc(`${SELECTOR_ID}-ea-0`, {
+        userID: 'ea-0',
+        relationshipSelectorID: SELECTOR_ID,
+        relationshipRankings: [fullRelID, ...relationshipIDs.filter((r) => r !== fullRelID)],
+        assignedRelationships: [{ relationshipID: fullRelID, assignedUserIDs: ['ea-0', 'ea-1'] }]
+      }),
+      makeDoc(`${SELECTOR_ID}-ea-1`, {
+        userID: 'ea-1',
+        relationshipSelectorID: SELECTOR_ID,
+        relationshipRankings: [fullRelID, ...relationshipIDs.filter((r) => r !== fullRelID)],
+        assignedRelationships: [{ relationshipID: fullRelID, assignedUserIDs: ['ea-0', 'ea-1'] }]
+      })
+    ];
+
+    // New user who ranks rel-0 first (but it's full)
+    const newDoc = makeDoc(`${SELECTOR_ID}-new-0`, {
+      userID: 'new-0',
+      relationshipSelectorID: SELECTOR_ID,
+      relationshipRankings: [fullRelID, ...relationshipIDs.filter((r) => r !== fullRelID)],
+      assignedRelationships: []
+    });
+
+    assignmentDocs = [...alreadyAssignedDocs, newDoc];
+
+    // Relationships: rel-0 has capacity exactly 2 (now full)
+    const { database } = await import('$lib/database');
+    const cappedRels = relationshipIDs.map((id, i) =>
+      makeDoc(id, { name: `Rel ${i}`, capacity: id === fullRelID ? 2 : 50, size: 2, type: '', fields: {} })
+    );
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => cappedRels.find((r) => r.id === id))
+    }) as any);
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // new-0 must NOT have been assigned to rel-0 (it's at capacity)
+    const newUserOp = batchOps.find((op) => op.path.includes('new-0'));
+    expect(newUserOp).toBeDefined();
+    const assignedRels = (newUserOp!.data as { assignedRelationships: { relationshipID: string }[] })
+      .assignedRelationships.map((ar) => ar.relationshipID);
+    expect(assignedRels).not.toContain(fullRelID);
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
+
+  it('patches existing participants docs when new members join their relationship', async () => {
+    // E1 is assigned to rel-0. A new user N1 also gets rel-0 assigned.
+    // E1's doc should be updated with the new combined assignedUserIDs.
+    const sharedRelID = relationshipIDs[0];
+
+    const e1Doc = makeDoc(`${SELECTOR_ID}-e1`, {
+      userID: 'e1',
+      relationshipSelectorID: SELECTOR_ID,
+      // E1 ranked rel-0 first but didn't get it (impossible in isolation, but we
+      // force it via alreadyAssigned: they *are* assigned to it already)
+      relationshipRankings: [sharedRelID, ...relationshipIDs.slice(1)],
+      assignedRelationships: [
+        { relationshipID: sharedRelID, assignedUserIDs: ['e1'] } // incomplete tuple
+      ]
+    });
+
+    // New participant who ranks rel-0 first
+    const n1Doc = makeDoc(`${SELECTOR_ID}-n1`, {
+      userID: 'n1',
+      relationshipSelectorID: SELECTOR_ID,
+      relationshipRankings: [sharedRelID, ...relationshipIDs.slice(1)],
+      assignedRelationships: []
+    });
+
+    assignmentDocs = [e1Doc, n1Doc];
+
+    // rel-0 has capacity 1 remaining (1 existing, base capacity 2)
+    const { database } = await import('$lib/database');
+    const patchRels = relationshipIDs.map((id, i) =>
+      makeDoc(id, { name: `Rel ${i}`, capacity: 2, size: 2, type: '', fields: {} })
+    );
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => patchRels.find((r) => r.id === id))
+    }) as any);
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // E1's doc should be updated with n1 in the assignedUserIDs for rel-0
+    const e1Op = batchOps.find((op) => op.path.includes(`${SELECTOR_ID}-e1`));
+    expect(e1Op).toBeDefined();
+    const e1Rels = (e1Op!.data as { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] })
+      .assignedRelationships;
+    const sharedRel = e1Rels.find((ar) => ar.relationshipID === sharedRelID);
+    expect(sharedRel).toBeDefined();
+    expect(sharedRel!.assignedUserIDs).toContain('e1');
+    expect(sharedRel!.assignedUserIDs).toContain('n1');
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
+
+  it('uses existing ranked-but-unassigned users as fill candidates for new-round tuples', async () => {
+    // Scenario: E1 is already assigned to rel-0. They also ranked rel-1 (rank 2) but didn't get it.
+    // N1 is a new participant who gets matched to rel-1 (the only new match, size 2 tuple → needs 1 fill).
+    // fillTuples should pull E1 in as the fill candidate for rel-1.
+    const rel0 = 'rel-0';
+    const rel1 = 'rel-1';
+    const FILL_SELECTOR_ID = 'fill-selector';
+
+    const fillSelector = makeDoc(FILL_SELECTOR_ID, {
+      name: 'Fill Test Selector',
+      relationshipIDs: [rel0, rel1],
+      relationshipsPerCharacter: 1
+    });
+
+    const fillRels = [
+      makeDoc(rel0, { name: 'Rel 0', capacity: 0, size: 2, type: '', fields: {} }),
+      makeDoc(rel1, { name: 'Rel 1', capacity: 0, size: 2, type: '', fields: {} })
+    ];
+
+    const { database } = await import('$lib/database');
+    vi.mocked(database.relationshipSelectors!.doc).mockReturnValueOnce({
+      read: vi.fn(async () => fillSelector)
+    } as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => fillRels.find((r) => r.id === id))
+    }) as any);
+
+    // E1: already assigned to rel-0, also ranked rel-1 (rank 2)
+    const e1Doc = makeDoc(`${FILL_SELECTOR_ID}-e1`, {
+      userID: 'e1-fill',
+      relationshipSelectorID: FILL_SELECTOR_ID,
+      relationshipRankings: [rel0, rel1], // rel0=rank1, rel1=rank2
+      assignedRelationships: [
+        { relationshipID: rel0, assignedUserIDs: ['e1-fill', 'e2-fill'] }
+      ]
+    });
+
+    // N1: new participant, ranks rel-1 first
+    const n1Doc = makeDoc(`${FILL_SELECTOR_ID}-n1`, {
+      userID: 'n1-fill',
+      relationshipSelectorID: FILL_SELECTOR_ID,
+      relationshipRankings: [rel1, rel0],
+      assignedRelationships: []
+    });
+
+    assignmentDocs = [e1Doc, n1Doc];
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: FILL_SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // N1 gets rel-1. fillTuples should add E1 (ranked rel-1 at rank-2, not assigned to it).
+    const n1Op = batchOps.find((op) => op.path.includes('n1-fill'));
+    expect(n1Op).toBeDefined();
+    const n1Rels = (n1Op!.data as { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] })
+      .assignedRelationships;
+    const n1Rel1 = n1Rels.find((ar) => ar.relationshipID === rel1);
+    expect(n1Rel1).toBeDefined();
+    // Both n1-fill and e1-fill should be in the assignedUserIDs (completed tuple)
+    expect(n1Rel1!.assignedUserIDs).toContain('n1-fill');
+    expect(n1Rel1!.assignedUserIDs).toContain('e1-fill');
+
+    // E1's doc should now include rel-1 as a newly fill-added relationship
+    const e1Op = batchOps.find((op) => op.path.includes('e1-fill'));
+    expect(e1Op).toBeDefined();
+    const e1Rels = (e1Op!.data as { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] })
+      .assignedRelationships;
+    const e1Rel1 = e1Rels.find((ar) => ar.relationshipID === rel1);
+    expect(e1Rel1).toBeDefined();
+    expect(e1Rel1!.assignedUserIDs).toContain('n1-fill');
+    expect(e1Rel1!.assignedUserIDs).toContain('e1-fill');
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
 });


### PR DESCRIPTION
When the matchmaking algorithm is run, and then more characters are created, the matchmaking can be run again, assigning only the unmatched characters to relationships.

Consider the case where only one character is unmatched - running the matchmaking a second time will try to balance that one character with another character, to do so it must draw upon the existing characters.

For this reason, any time we have to balance out the new relationship assignments, a character from the new batch might be matched with a character who already got their assignments.

This also fixes several bugs and UI/UX issues around sharing the matches with participants. 