### PR TITLE
adding toggles for sharing relationships with participants

### DIFF
--- a/src/lib/characters/PurchasedRelationshipRow.svelte
+++ b/src/lib/characters/PurchasedRelationshipRow.svelte
@@ -8,6 +8,7 @@
 
 	export let relationship: Docs.Relationship | null = null;
 	export let assignedUserIDs: string[] = [];
+	export let shared: boolean = false;
 	export let getPartnerName: (userID: string) => string = (id) => id;
 	export let namesLoading: boolean = false;
 
@@ -46,7 +47,7 @@
 				</div>
 			</div>
 		{/each}
-		{#if assignedUserIDs.length > 0}
+		{#if assignedUserIDs.length > 0 && shared}
 			<div class="partners mt1">
 				<span class="">Assigned:</span>
 				<div class="flex flex-wrap g1 mt1">

--- a/src/lib/characters/PurchasedRelationshipSelectorRow.svelte
+++ b/src/lib/characters/PurchasedRelationshipSelectorRow.svelte
@@ -68,6 +68,7 @@
             <PurchasedRelationshipRow
                 {relationship}
                 assignedUserIDs={rel.assignedUserIDs ?? []}
+                shared={rel.shared ?? false}
                 {getPartnerName}
                 {namesLoading}
             />

--- a/src/lib/database/types/RelationshipAssignments.ts
+++ b/src/lib/database/types/RelationshipAssignments.ts
@@ -1,6 +1,7 @@
 interface AssignedRelationship {
     assignedUserIDs: string[];
     relationshipID: string;
+    shared: boolean;
 }
 
 export interface RelationshipAssignment {

--- a/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
+++ b/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
@@ -53,6 +53,7 @@
 	// ── Algorithm execution state ──────────────────────────────────────────────
 	let running: Record<string, boolean> = {};
 	let clearing: Record<string, boolean> = {};
+	let sharing: Record<string, boolean> = {};
 
 	// ── Manual edit state ──────────────────────────────────────────────────────
 	// Editing means: swap a specific user out of a specific relationship
@@ -141,6 +142,56 @@
 			sendNotification({ text: 'Network error clearing assignments' });
 		} finally {
 			clearing = { ...clearing, [selectorID]: false };
+		}
+	};
+
+	// ── Share assignments ──────────────────────────────────────────────────────
+	const isSelectorShared = (selectorID: string): boolean => {
+		const assignments = $assignmentsBySelectorId[selectorID] ?? [];
+		const withAssignments = assignments.filter(
+			(a) => Array.isArray(a.data.assignedRelationships) && a.data.assignedRelationships.length > 0
+		);
+		if (withAssignments.length === 0) return false;
+		return withAssignments.every((a) =>
+			(a.data.assignedRelationships ?? []).every((r) => r.shared === true)
+		);
+	};
+
+	const isRelationshipShared = (selectorID: string, relationshipID: string): boolean => {
+		const assignments = $assignmentsBySelectorId[selectorID] ?? [];
+		for (const a of assignments) {
+			const entry = (a.data.assignedRelationships ?? []).find(
+				(r) => r.relationshipID === relationshipID
+			);
+			if (entry) return entry.shared === true;
+		}
+		return false;
+	};
+
+	const shareRelationships = async (selectorID: string, shared: boolean, relationshipID?: string) => {
+		const key = relationshipID ? `${selectorID}:${relationshipID}` : selectorID;
+		sharing = { ...sharing, [key]: true };
+		try {
+			const res = await fetch('/api/relationships/share', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					gameID,
+					relationshipSelectorID: selectorID,
+					shared,
+					...(relationshipID ? { relationshipID } : {})
+				})
+			});
+			const body = await res.json();
+			if (body.success) {
+				sendNotification({ text: shared ? 'Shared with participants' : 'Hidden from participants' });
+			} else {
+				sendNotification({ text: `Error: ${body.message ?? 'Unknown error'}` });
+			}
+		} catch (err) {
+			sendNotification({ text: 'Network error sharing assignments' });
+		} finally {
+			sharing = { ...sharing, [key]: false };
 		}
 	};
 
@@ -326,9 +377,23 @@
 
 						<div class="flex g1 items-center">
 							{#if selectorHasAssignments}
-								<span class="chip bg-success text-on-success">
-									<Icon>check_circle</Icon> Assigned
-								</span>
+							{@const isSelectorSharedNow = isSelectorShared(selector.id)}
+							<span class="chip bg-success text-on-success">
+								<Icon>check_circle</Icon> Assigned
+							</span>
+							{#if sharing[selector.id]}
+								<Spinner />
+							{:else}
+								<button
+									class="share-toggle"
+									class:active={isSelectorSharedNow}
+									title={isSelectorSharedNow ? 'Unshare with participants' : 'Share with participants'}
+									on:click={() => shareRelationships(selector.id, !isSelectorSharedNow)}
+								>
+									<Icon>{isSelectorSharedNow ? 'visibility' : 'visibility_off'}</Icon>
+									{isSelectorSharedNow ? 'Shared' : 'Share with participants'}
+								</button>
+							{/if}
 							<ConfirmButton on:confirm={() => clearAssignments(selector.id)} />
 							{:else}
 								{#if isRunning}
@@ -362,19 +427,32 @@
 								<div class="rosters">
 									{#each rosters as { relationshipID, userIDs } (relationshipID)}
 										{@const rel = $relationshipsById[relationshipID]}
-										<div class="roster-section mb3">
-											<div class="flex items-center g1 mb1">
-												<h3 class="my0">{rel?.data?.name ?? relationshipID}</h3>
-												<span class="chip bg-secondary">
-													{userIDs.length} / {rel?.data?.capacity > 0 ? rel.data.capacity : '∞'}
-													· size {rel?.data?.size ?? 2}
-												</span>
-											</div>
-
-											{#if userIDs.length === 0}
-												<p class="muted h5">No one assigned yet.</p>
+									{@const isRelShared = isRelationshipShared(selector.id, relationshipID)}
+									<div class="roster-section mb3">
+										<div class="flex items-center g1 mb1">
+											<h3 class="my0">{rel?.data?.name ?? relationshipID}</h3>
+											<span class="chip bg-secondary">
+												{userIDs.length} / {rel?.data?.capacity > 0 ? rel.data.capacity : '∞'}
+												· size {rel?.data?.size ?? 2}
+											</span>
+											{#if sharing[`${selector.id}:${relationshipID}`]}
+												<Spinner />
 											{:else}
-												<!-- Group into tuples of `size` -->
+												<button
+													class="share-toggle share-toggle--sm"
+													class:active={isRelShared}
+													title={isRelShared ? 'Unshare with participants' : 'Share with participants'}
+													on:click={() => shareRelationships(selector.id, !isRelShared, relationshipID)}
+												>
+													<Icon>{isRelShared ? 'visibility' : 'visibility_off'}</Icon>
+												</button>
+											{/if}
+									</div>
+
+									{#if userIDs.length === 0}
+										<p class="muted h5">No one assigned yet.</p>
+									{:else}
+										<!-- Group into tuples of `size` -->
 												{@const tupleSize = rel?.data?.size ?? 2}
 												{#each Array.from({ length: Math.ceil(userIDs.length / tupleSize) }, (_, i) => userIDs.slice(i * tupleSize, (i + 1) * tupleSize)) as tuple, tupleIndex}
 													<div class="tuple-row flex items-center g1 mb1 p1 rounded bg-secondary">
@@ -484,6 +562,31 @@
 
 	.rosters {
 		padding-top: 1rem;
+	}
+
+	.share-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		background: none;
+		border: 1px solid var(--surface);
+		border-radius: 12px;
+		padding: 0.15rem 0.6rem;
+		cursor: pointer;
+		color: inherit;
+		font-size: 0.8rem;
+		white-space: nowrap;
+	}
+
+	.share-toggle.active {
+		background: var(--primary);
+		color: var(--on-primary);
+		border-color: var(--primary);
+	}
+
+	.share-toggle--sm {
+		padding: 0.1rem 0.35rem;
+		font-size: 0.75rem;
 	}
 
 	.user-list {

--- a/src/routes/api/relationships/assignRelationships/+server.ts
+++ b/src/routes/api/relationships/assignRelationships/+server.ts
@@ -122,13 +122,14 @@ export const POST: RequestHandler = async (event) => {
 		}
 
 		// Every participant who submitted rankings gets a doc written (even if unmatched)
-		type WriteOp = { path: string; data: { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] } };
+		type WriteOp = { path: string; data: { assignedRelationships: { relationshipID: string; assignedUserIDs: string[]; shared: boolean }[] } };
 		const ops: WriteOp[] = assignments.map((assignment) => {
 			const userID = assignment.data.userID;
 			const assignedRelIDs = userAssignments.get(userID) ?? [];
 			const assignedRelationships = assignedRelIDs.map((relID) => ({
 				relationshipID: relID,
-				assignedUserIDs: rosters.get(relID) ?? []
+				assignedUserIDs: rosters.get(relID) ?? [],
+				shared: false
 			}));
 			const key = relationshipAssignmentKey(relationshipSelectorID, userID);
 			return { path: `games/${gameID}/relationshipAssignments/${key}`, data: { assignedRelationships } };

--- a/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
+++ b/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
@@ -214,8 +214,19 @@ describe('POST /api/relationships/assignRelationships', () => {
     await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
 
     for (const op of batchOps) {
-      const data = op.data as { assignedRelationships: { relationshipID: string }[] };
+      const data = op.data as { assignedRelationships: { relationshipID: string; assignedUserIDs: string[]; shared: boolean }[] };
       expect(data.assignedRelationships.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('all written assignedRelationship entries have shared: false', async () => {
+    await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+
+    for (const op of batchOps) {
+      const data = op.data as { assignedRelationships: { relationshipID: string; assignedUserIDs: string[]; shared: boolean }[] };
+      for (const ar of data.assignedRelationships) {
+        expect(ar.shared).toBe(false);
+      }
     }
   });
 

--- a/src/routes/api/relationships/share/+server.ts
+++ b/src/routes/api/relationships/share/+server.ts
@@ -1,0 +1,75 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { database, setGameID } from '$lib/database';
+import { isEditor } from '$lib/permissions';
+import type { Docs } from '$lib/database/types';
+
+/**
+ * POST /api/relationships/share
+ *
+ * Sets the `shared` flag on AssignedRelationship entries for a given
+ * RelationshipSelector. When `relationshipID` is provided, only entries
+ * matching that relationship are updated; otherwise all entries are updated.
+ *
+ * Body: { gameID: string, relationshipSelectorID: string, shared: boolean, relationshipID?: string }
+ *
+ * Returns: { success: true, updated: number } | { success: false, message: string }
+ */
+export const POST: RequestHandler = async (event) => {
+	const payload = await event.request.json();
+	const gameID: string = payload.gameID || '';
+	const relationshipSelectorID: string = payload.relationshipSelectorID || '';
+	const shared: boolean | undefined = payload.shared;
+	const relationshipID: string | undefined = payload.relationshipID || undefined;
+
+	if (!event.locals.decodedToken) {
+		return json({ success: false, message: 'Not authenticated' });
+	}
+	if (!gameID || !relationshipSelectorID) {
+		return json({ success: false, message: 'Missing gameID or relationshipSelectorID' });
+	}
+	if (shared === undefined || shared === null) {
+		return json({ success: false, message: 'Missing shared value' });
+	}
+	if (!isEditor(event.locals.user.roles, gameID)) {
+		return json({ success: false, message: 'Insufficient permissions' });
+	}
+
+	try {
+		setGameID(gameID);
+
+		const allAssignments: Docs.RelationshipAssignment[] =
+			await database.relationshipAssignments
+				?.withQueries({ field: 'relationshipSelectorID', op: '==', value: relationshipSelectorID })
+				.read() ?? [];
+
+		const assignmentsWithData = allAssignments.filter(
+			(a) => Array.isArray(a.data.assignedRelationships) && a.data.assignedRelationships.length > 0
+		);
+
+		let updated = 0;
+
+		await Promise.all(
+			assignmentsWithData.map(async (assignment) => {
+				const existing = assignment.data.assignedRelationships;
+				let changed = false;
+
+				const next = existing.map((rel) => {
+					if (relationshipID && rel.relationshipID !== relationshipID) return rel;
+					if (rel.shared === shared) return rel;
+					changed = true;
+					return { ...rel, shared };
+				});
+
+				if (!changed) return;
+
+				await database.relationshipAssignments?.doc(assignment.id)?.update({ assignedRelationships: next });
+				updated++;
+			})
+		);
+
+		return json({ success: true, updated });
+	} catch (err: any) {
+		console.error('share error:', err);
+		return json({ success: false, message: (err as Error).message ?? String(err) });
+	}
+};

--- a/src/routes/api/relationships/share/__tests__/share.spec.ts
+++ b/src/routes/api/relationships/share/__tests__/share.spec.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for POST /api/relationships/share
+ *
+ * Strategy: mock $lib/database and $lib/permissions, then call the POST
+ * handler directly.
+ *
+ * Contract under test:
+ *   - auth / permission guards return early with descriptive errors
+ *   - missing `shared` value returns an error
+ *   - selector-level share (no relationshipID): all AssignedRelationship entries updated
+ *   - relationship-level share (with relationshipID): only matching entries updated
+ *   - un-share: shared: false propagates correctly
+ *   - already-matching entries are skipped (update() not called unnecessarily)
+ *   - returns updated: 0 when nothing has assignedRelationships
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../+server';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAssignedRelationship(
+  relationshipID: string,
+  shared: boolean,
+  assignedUserIDs: string[] = ['u1', 'u2']
+) {
+  return { relationshipID, assignedUserIDs, shared };
+}
+
+function makeDoc<T>(id: string, data: T, exists = true) {
+  return { id, data, exists, update: vi.fn().mockResolvedValue(undefined) };
+}
+
+// ── Fixture data ──────────────────────────────────────────────────────────────
+
+const GAME_ID = 'game-share-test';
+const SELECTOR_ID = 'selector-share';
+
+// 3 docs with assignments, 2 without
+function makeAssignmentDocs() {
+  return [
+    makeDoc(`${SELECTOR_ID}-user-1`, {
+      userID: 'user-1',
+      relationshipSelectorID: SELECTOR_ID,
+      relationshipRankings: ['rel-a', 'rel-b'],
+      assignedRelationships: [
+        makeAssignedRelationship('rel-a', false),
+        makeAssignedRelationship('rel-b', false)
+      ]
+    }),
+    makeDoc(`${SELECTOR_ID}-user-2`, {
+      userID: 'user-2',
+      relationshipSelectorID: SELECTOR_ID,
+      relationshipRankings: ['rel-b', 'rel-a'],
+      assignedRelationships: [
+        makeAssignedRelationship('rel-a', false),
+        makeAssignedRelationship('rel-b', false)
+      ]
+    }),
+    makeDoc(`${SELECTOR_ID}-user-3`, {
+      userID: 'user-3',
+      relationshipSelectorID: SELECTOR_ID,
+      relationshipRankings: ['rel-a'],
+      assignedRelationships: [
+        makeAssignedRelationship('rel-a', false)
+      ]
+    }),
+    // No assigned relationships — should not be touched
+    makeDoc(`${SELECTOR_ID}-user-4`, {
+      userID: 'user-4',
+      relationshipSelectorID: SELECTOR_ID,
+      relationshipRankings: ['rel-a', 'rel-b'],
+      assignedRelationships: []
+    }),
+    // Already shared for rel-a — used in skip test
+    makeDoc(`${SELECTOR_ID}-user-5`, {
+      userID: 'user-5',
+      relationshipSelectorID: SELECTOR_ID,
+      relationshipRankings: ['rel-a'],
+      assignedRelationships: [
+        makeAssignedRelationship('rel-a', true)
+      ]
+    })
+  ];
+}
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+let assignmentDocs: ReturnType<typeof makeDoc>[];
+
+vi.mock('$lib/permissions', () => ({
+  isEditor: vi.fn().mockReturnValue(true)
+}));
+
+vi.mock('$lib/database', () => {
+  const setGameID = vi.fn();
+  const database = {
+    relationshipAssignments: {
+      withQueries: vi.fn(() => ({
+        read: vi.fn(async () => assignmentDocs)
+      })),
+      doc: vi.fn((id: string) => assignmentDocs.find((d) => d.id === id) ?? {
+        update: vi.fn().mockResolvedValue(undefined)
+      })
+    }
+  };
+  return { database, setGameID };
+});
+
+// ── Fake RequestEvent factory ─────────────────────────────────────────────────
+
+function makeEvent(body: object, overrides: { decodedToken?: unknown; user?: unknown } = {}) {
+  return {
+    request: { json: vi.fn(async () => body) },
+    locals: {
+      decodedToken: 'decodedToken' in overrides ? overrides.decodedToken : { uid: 'admin-uid' },
+      user: overrides.user ?? { roles: { system: 4 } }
+    }
+  } as any;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/relationships/share', () => {
+  beforeEach(async () => {
+    assignmentDocs = makeAssignmentDocs();
+    vi.clearAllMocks();
+    vi.mocked((await import('$lib/permissions')).isEditor).mockReturnValue(true);
+  });
+
+  // ── Auth / permission guards ────────────────────────────────────────────────
+
+  it('returns error when not authenticated', async () => {
+    const res = await POST(makeEvent(
+      { gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID, shared: true },
+      { decodedToken: null }
+    ));
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.message).toMatch(/not authenticated/i);
+  });
+
+  it('returns error when gameID is missing', async () => {
+    const res = await POST(makeEvent({ relationshipSelectorID: SELECTOR_ID, shared: true }));
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.message).toMatch(/missing/i);
+  });
+
+  it('returns error when relationshipSelectorID is missing', async () => {
+    const res = await POST(makeEvent({ gameID: GAME_ID, shared: true }));
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.message).toMatch(/missing/i);
+  });
+
+  it('returns error when shared is missing', async () => {
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.message).toMatch(/missing shared/i);
+  });
+
+  it('returns error when not an editor', async () => {
+    const { isEditor } = await import('$lib/permissions');
+    vi.mocked(isEditor).mockReturnValueOnce(false);
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID, shared: true }));
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.message).toMatch(/permission/i);
+  });
+
+  // ── Selector-level sharing ─────────────────────────────────────────────────
+
+  it('selector-level share: updates all docs that have assignedRelationships', async () => {
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID, shared: true }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    // 3 docs have assignedRelationships (user-1, user-2, user-3); user-4 is empty; user-5 is already shared
+    // user-5's rel-a is already shared: true — no change needed, so update() not called
+    // user-1, user-2, user-3 all need updating
+    expect(body.updated).toBe(3);
+  });
+
+  it('selector-level share: sets shared: true on all entries', async () => {
+    await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID, shared: true }));
+
+    for (const doc of assignmentDocs.filter((d) => d.data.assignedRelationships.length > 0)) {
+      if (doc.update.mock.calls.length === 0) continue; // already-matching docs are skipped
+      const written = doc.update.mock.calls[0][0] as { assignedRelationships: { shared: boolean }[] };
+      for (const ar of written.assignedRelationships) {
+        expect(ar.shared).toBe(true);
+      }
+    }
+  });
+
+  it('selector-level un-share: sets shared: false on all entries', async () => {
+    // First share everything
+    assignmentDocs = makeAssignmentDocs().map((d) => ({
+      ...d,
+      data: {
+        ...d.data,
+        assignedRelationships: d.data.assignedRelationships.map((r: any) => ({ ...r, shared: true }))
+      }
+    }));
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID, shared: false }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    for (const doc of assignmentDocs.filter((d) => d.update.mock.calls.length > 0)) {
+      const written = doc.update.mock.calls[0][0] as { assignedRelationships: { shared: boolean }[] };
+      for (const ar of written.assignedRelationships) {
+        expect(ar.shared).toBe(false);
+      }
+    }
+  });
+
+  it('returns updated: 0 when no docs have assignedRelationships', async () => {
+    assignmentDocs = [
+      makeDoc(`${SELECTOR_ID}-empty`, {
+        userID: 'empty-user',
+        relationshipSelectorID: SELECTOR_ID,
+        relationshipRankings: [],
+        assignedRelationships: []
+      })
+    ];
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID, shared: true }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.updated).toBe(0);
+  });
+
+  // ── Relationship-level sharing ─────────────────────────────────────────────
+
+  it('relationship-level share: only updates entries matching the given relationshipID', async () => {
+    const res = await POST(makeEvent({
+      gameID: GAME_ID,
+      relationshipSelectorID: SELECTOR_ID,
+      shared: true,
+      relationshipID: 'rel-a'
+    }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    // user-1, user-2, user-3 all have rel-a with shared: false — need updating
+    // user-5 has rel-a with shared: true — already matches, skipped
+    expect(body.updated).toBe(3);
+  });
+
+  it('relationship-level share: does not touch entries for other relationships', async () => {
+    await POST(makeEvent({
+      gameID: GAME_ID,
+      relationshipSelectorID: SELECTOR_ID,
+      shared: true,
+      relationshipID: 'rel-a'
+    }));
+
+    // user-1 has rel-a and rel-b; only rel-a should change
+    const user1Doc = assignmentDocs.find((d) => d.data.userID === 'user-1')!;
+    expect(user1Doc.update).toHaveBeenCalledOnce();
+    const written = user1Doc.update.mock.calls[0][0] as {
+      assignedRelationships: { relationshipID: string; shared: boolean }[]
+    };
+    const relA = written.assignedRelationships.find((r) => r.relationshipID === 'rel-a')!;
+    const relB = written.assignedRelationships.find((r) => r.relationshipID === 'rel-b')!;
+    expect(relA.shared).toBe(true);
+    expect(relB.shared).toBe(false); // unchanged
+  });
+
+  // ── Skip unchanged docs ────────────────────────────────────────────────────
+
+  it('does not call update() on docs where all entries already match', async () => {
+    // user-5 has rel-a already shared; sharing it again should be a no-op for that doc
+    const res = await POST(makeEvent({
+      gameID: GAME_ID,
+      relationshipSelectorID: SELECTOR_ID,
+      shared: true,
+      relationshipID: 'rel-a'
+    }));
+    const user5Doc = assignmentDocs.find((d) => d.data.userID === 'user-5')!;
+    expect(user5Doc.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
selector-level and relationship-level toggles allow admins and editors to control when participants can see their relationship assignments