### PR TITLE
Relationship Assignment bugfixes and enhanced capabilities

### DIFF
--- a/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
+++ b/src/routes/admin/games/[gameID]/relationshipAssignments/+page.svelte
@@ -60,6 +60,7 @@
 	let running: Record<string, boolean> = {};
 	let clearing: Record<string, boolean> = {};
 	let sharing: Record<string, boolean> = {};
+	let deletingGroups: Record<string, boolean> = {};
 
 	// ── Manual edit state ──────────────────────────────────────────────────────
 	// Editing means: swap a specific user out of a specific relationship.
@@ -114,13 +115,15 @@
 	};
 
 	// ── Count participants with rankings but no assignment yet ─────────────────
-	const countUnassigned = (selectorID: string): number => {
+	const countUnassigned = (selector: Docs.RelationshipSelector): number => {
+		const selectorID = selector.id;
+		const expectedCount = selector.data.relationshipsPerCharacter ?? 1;
 		const assignments = $assignmentsBySelectorId[selectorID] ?? [];
 		return assignments.filter(
 			(a) =>
 				Array.isArray(a.data.relationshipRankings) &&
 				a.data.relationshipRankings.length > 0 &&
-				(!Array.isArray(a.data.assignedRelationships) || a.data.assignedRelationships.length === 0)
+				((a.data.assignedRelationships ?? []).length < expectedCount)
 		).length;
 	};
 
@@ -166,6 +169,37 @@
 			sendNotification({ text: 'Network error clearing assignments' });
 		} finally {
 			clearing = { ...clearing, [selectorID]: false };
+		}
+	};
+
+	const tupleKey = (tuple: string[]): string => [...tuple].sort().join('|');
+
+	// ── Delete one relationship group (tuple) only ───────────────────────────
+	const deleteAssignedGroup = async (selectorID: string, relationshipID: string, tuple: string[]) => {
+		if (!Array.isArray(tuple) || tuple.length === 0) return;
+		const key = `${selectorID}:${relationshipID}:${tupleKey(tuple)}`;
+		deletingGroups = { ...deletingGroups, [key]: true };
+		try {
+			const res = await fetch('/api/relationships/deleteAssignedGroup', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					gameID,
+					relationshipSelectorID: selectorID,
+					relationshipID,
+					tupleUserIDs: tuple
+				})
+			});
+			const body = await res.json();
+			if (body.success) {
+				sendNotification({ text: `Deleted group for ${body.updated} participant(s)` });
+			} else {
+				sendNotification({ text: `Error: ${body.message ?? 'Unknown error'}` });
+			}
+		} catch (err) {
+			sendNotification({ text: 'Network error deleting assigned group' });
+		} finally {
+			deletingGroups = { ...deletingGroups, [key]: false };
 		}
 	};
 
@@ -424,7 +458,7 @@
 			{#each $relationshipSelectors as selector (selector.id)}
 				{@const selectorHasAssignments = hasAssignments(selector.id)}
 				{@const rankingCount = countRankings(selector.id)}
-				{@const unassignedCount = countUnassigned(selector.id)}
+				{@const unassignedCount = countUnassigned(selector)}
 				{@const isRunning = running[selector.id]}
 				{@const isClearing = clearing[selector.id]}
 				{@const isExpanded = $expanded[selector.id] ?? false}
@@ -550,6 +584,16 @@
 													</button>
 												{/if}
 											</div>
+											<div class="tuple-actions">
+												{#if deletingGroups[`${selector.id}:${relationshipID}:${tupleKey(tuple)}`]}
+													<Spinner />
+												{:else}
+													<ConfirmButton
+														icon="delete"
+														on:confirm={() => deleteAssignedGroup(selector.id, relationshipID, tuple)}
+													/>
+												{/if}
+											</div>
 										</div>
 									{/each}
 								{/if}
@@ -627,6 +671,11 @@
 
 	.tuple-row {
 		border: 1px solid var(--surface);
+	}
+
+	.tuple-actions {
+		display: inline-flex;
+		align-items: center;
 	}
 
 	.user-chip {

--- a/src/routes/api/relationships/assignRelationships/+server.ts
+++ b/src/routes/api/relationships/assignRelationships/+server.ts
@@ -157,6 +157,13 @@ export const POST: RequestHandler = async (event) => {
 		// newRosters: Map<relID, newRoundUserIDs[]> — new-round additions only
 		const newRosters = matcher.fillTuples(matching, tupleSizes, existingCandidates);
 
+		// Matched new participants by relationship (excludes fill-only additions).
+		const matchedNewByRelID = new Map<string, string[]>();
+		for (const { applicant, post } of matching) {
+			if (!matchedNewByRelID.has(post)) matchedNewByRelID.set(post, []);
+			matchedNewByRelID.get(post)!.push(applicant);
+		}
+
 		// ── 7. Write results to Firestore via batched writes ────────────────────
 		// Preserve existing tuple memberships exactly as stored, keyed by rel/user.
 		const existingTupleByRelUser = new Map<string, Map<string, string[]>>();
@@ -186,7 +193,9 @@ export const POST: RequestHandler = async (event) => {
 
 		// If a relationship already has incomplete tuples, rebalance that relationship
 		// with new-round additions so incomplete groups can be completed.
+		// Fill is capped to exactly the deficit so we do not create a new orphan tuple.
 		const rebalancedTuplesByRelID = new Map<string, string[][]>();
+		const effectiveNewRostersByRelID = new Map<string, string[]>();
 		for (const [relID, tuples] of existingTuplesByRelID) {
 			const size = tupleSizes.get(relID) ?? 2;
 			const hasIncomplete = tuples.some((t) => t.length < size);
@@ -203,18 +212,46 @@ export const POST: RequestHandler = async (event) => {
 				}
 			}
 
-			const added = newRosters.get(relID) ?? [];
-			const combined = [...existingFlat, ...added.filter((uid) => !seen.has(uid))];
+			const existingSet = new Set(existingFlat);
+			const matchedNew = matchedNewByRelID.get(relID) ?? [];
+			const matchedNewSet = new Set(matchedNew);
+
+			const baseCombined = [
+				...existingFlat,
+				...matchedNew.filter((uid) => !existingSet.has(uid))
+			];
+
+			const remainder = baseCombined.length % size;
+			const neededFill = remainder === 0 ? 0 : size - remainder;
+
+			const fillCandidates = (newRosters.get(relID) ?? []).filter(
+				(uid) => !existingSet.has(uid) && !matchedNewSet.has(uid)
+			);
+			const cappedFill = fillCandidates.slice(0, neededFill);
+
+			const combined = [...baseCombined, ...cappedFill];
 			const rebalanced: string[][] = [];
 			for (let i = 0; i < combined.length; i += size) {
 				rebalanced.push(combined.slice(i, i + size));
 			}
 			rebalancedTuplesByRelID.set(relID, rebalanced);
+
+			effectiveNewRostersByRelID.set(
+				relID,
+				combined.filter((uid) => !existingSet.has(uid))
+			);
+		}
+
+		// For relationships without incomplete existing tuples, keep matcher output as-is.
+		for (const [relID, roster] of newRosters) {
+			if (!effectiveNewRostersByRelID.has(relID)) {
+				effectiveNewRostersByRelID.set(relID, roster);
+			}
 		}
 
 		// Build tuples only for new-round additions. Existing tuples are not re-sliced.
 		const newTuplesByRelID = new Map<string, string[][]>();
-		for (const [relID, roster] of newRosters) {
+		for (const [relID, roster] of effectiveNewRostersByRelID) {
 			const size = tupleSizes.get(relID) ?? 2;
 			const tuples: string[][] = [];
 			for (let i = 0; i < roster.length; i += size) {
@@ -239,14 +276,14 @@ export const POST: RequestHandler = async (event) => {
 
 		// Determine which relIDs gained new members this run
 		const changedRelIDs = new Set<string>(
-			[...newRosters.entries()]
+			[...effectiveNewRostersByRelID.entries()]
 				.filter(([, users]) => users.length > 0)
 				.map(([relID]) => relID)
 		);
 
 		// Build per-user assignment list for new participants from combined rosters
 		const newUserAssignments = new Map<string, string[]>();
-		for (const [relID, userIDs] of newRosters) {
+		for (const [relID, userIDs] of effectiveNewRostersByRelID) {
 			for (const userID of userIDs) {
 				// Only track new-round users (not existing fill candidates pulled in)
 				if (newAssignments.some((a) => a.data.userID === userID)) {
@@ -300,7 +337,7 @@ export const POST: RequestHandler = async (event) => {
 		// (they appear in newRosters but are not in newAssignments)
 		const newParticipantIDs = new Set(newAssignments.map((a) => a.data.userID));
 		const fillFromExisting = new Map<string, string[]>(); // userID -> relIDs they were fill-added to
-		for (const [relID, userIDs] of newRosters) {
+		for (const [relID, userIDs] of effectiveNewRostersByRelID) {
 			for (const userID of userIDs) {
 				if (!newParticipantIDs.has(userID)) {
 					// This is an existing user pulled in as a fill candidate

--- a/src/routes/api/relationships/assignRelationships/+server.ts
+++ b/src/routes/api/relationships/assignRelationships/+server.ts
@@ -164,115 +164,123 @@ export const POST: RequestHandler = async (event) => {
 			matchedNewByRelID.get(post)!.push(applicant);
 		}
 
+		// Fill-only additions by relationship (present in fillTuples output but not in matching output).
+		const fillOnlyByRelID = new Map<string, string[]>();
+		for (const [relID, roster] of newRosters) {
+			const matched = new Set(matchedNewByRelID.get(relID) ?? []);
+			fillOnlyByRelID.set(
+				relID,
+				roster.filter((uid) => !matched.has(uid))
+			);
+		}
+
 		// ── 7. Write results to Firestore via batched writes ────────────────────
-		// Preserve existing tuple memberships exactly as stored, keyed by rel/user.
-		const existingTupleByRelUser = new Map<string, Map<string, string[]>>();
 		const existingTuplesByRelID = new Map<string, string[][]>();
+		const existingMembersByRelID = new Map<string, Set<string>>();
+		const existingTupleByRelUser = new Map<string, Map<string, string[]>>();
+		const existingTupleKeysByRelID = new Map<string, Set<string>>();
 		for (const assignment of alreadyAssigned) {
 			for (const ar of assignment.data.assignedRelationships ?? []) {
-				if (!existingTupleByRelUser.has(ar.relationshipID)) {
-					existingTupleByRelUser.set(ar.relationshipID, new Map());
-				}
 				if (!existingTuplesByRelID.has(ar.relationshipID)) {
 					existingTuplesByRelID.set(ar.relationshipID, []);
 				}
+				if (!existingMembersByRelID.has(ar.relationshipID)) {
+					existingMembersByRelID.set(ar.relationshipID, new Set());
+				}
+				if (!existingTupleByRelUser.has(ar.relationshipID)) {
+					existingTupleByRelUser.set(ar.relationshipID, new Map());
+				}
+				if (!existingTupleKeysByRelID.has(ar.relationshipID)) {
+					existingTupleKeysByRelID.set(ar.relationshipID, new Set());
+				}
+
 				const byUser = existingTupleByRelUser.get(ar.relationshipID)!;
+				const members = existingMembersByRelID.get(ar.relationshipID)!;
+				const tupleKeys = existingTupleKeysByRelID.get(ar.relationshipID)!;
 				const tuple = Array.isArray(ar.assignedUserIDs) && ar.assignedUserIDs.length > 0
 					? ar.assignedUserIDs
 					: [assignment.data.userID];
 				const tuples = existingTuplesByRelID.get(ar.relationshipID)!;
 				const tupleKey = [...tuple].sort().join('|');
-				if (!tuples.some((t) => [...t].sort().join('|') === tupleKey)) {
+				if (!tupleKeys.has(tupleKey)) {
 					tuples.push(tuple);
+					tupleKeys.add(tupleKey);
 				}
 				for (const uid of tuple) {
+					members.add(uid);
 					byUser.set(uid, tuple);
 				}
 			}
 		}
 
-		// If a relationship already has incomplete tuples, rebalance that relationship
-		// with new-round additions so incomplete groups can be completed.
-		// Fill is capped to exactly the deficit so we do not create a new orphan tuple.
-		const rebalancedTuplesByRelID = new Map<string, string[][]>();
-		const effectiveNewRostersByRelID = new Map<string, string[]>();
-		for (const [relID, tuples] of existingTuplesByRelID) {
+		// Build deterministic final tuples per relationship:
+		// 1) Keep existing complete tuples intact
+		// 2) Repair existing incomplete tuples first
+		// 3) Form new tuples from remaining matched users, then fill-only candidates
+		const finalTuplesByRelID = new Map<string, string[][]>();
+		for (const rel of relationships) {
+			const relID = rel.id;
 			const size = tupleSizes.get(relID) ?? 2;
-			const hasIncomplete = tuples.some((t) => t.length < size);
-			if (!hasIncomplete) continue;
 
-			const seen = new Set<string>();
-			const existingFlat: string[] = [];
+			const existingTuples = existingTuplesByRelID.get(relID) ?? [];
+			const existingMembers = new Set(existingMembersByRelID.get(relID) ?? []);
+
+			const completeExisting = existingTuples.filter((t) => t.length >= size).map((t) => [...t]);
+			const incompleteExisting = existingTuples.filter((t) => t.length < size).map((t) => [...t]);
+
+			const matchedQueue = (matchedNewByRelID.get(relID) ?? []).filter((uid) => !existingMembers.has(uid));
+			const matchedSet = new Set(matchedQueue);
+			const fillQueue = (fillOnlyByRelID.get(relID) ?? []).filter(
+				(uid) => !existingMembers.has(uid) && !matchedSet.has(uid)
+			);
+
+			const finalTuples: string[][] = [...completeExisting];
+
+			for (const tuple of incompleteExisting) {
+				while (tuple.length < size && matchedQueue.length > 0) tuple.push(matchedQueue.shift()!);
+				while (tuple.length < size && fillQueue.length > 0) tuple.push(fillQueue.shift()!);
+				finalTuples.push(tuple);
+			}
+
+			while (matchedQueue.length > 0) {
+				const tuple: string[] = [];
+				while (tuple.length < size && matchedQueue.length > 0) tuple.push(matchedQueue.shift()!);
+				while (tuple.length < size && fillQueue.length > 0) tuple.push(fillQueue.shift()!);
+				finalTuples.push(tuple);
+			}
+
+			finalTuplesByRelID.set(relID, finalTuples);
+		}
+
+		const finalTupleByRelUser = new Map<string, Map<string, string[]>>();
+		const finalMembersByRelID = new Map<string, Set<string>>();
+		for (const [relID, tuples] of finalTuplesByRelID) {
+			if (!finalTupleByRelUser.has(relID)) finalTupleByRelUser.set(relID, new Map());
+			if (!finalMembersByRelID.has(relID)) finalMembersByRelID.set(relID, new Set());
+			const byUser = finalTupleByRelUser.get(relID)!;
+			const members = finalMembersByRelID.get(relID)!;
 			for (const tuple of tuples) {
 				for (const uid of tuple) {
-					if (!seen.has(uid)) {
-						seen.add(uid);
-						existingFlat.push(uid);
-					}
+					members.add(uid);
+					byUser.set(uid, tuple);
 				}
 			}
+		}
 
-			const existingSet = new Set(existingFlat);
-			const matchedNew = matchedNewByRelID.get(relID) ?? [];
-			const matchedNewSet = new Set(matchedNew);
+		const getUserTuple = (relID: string, userID: string): string[] => {
+			return finalTupleByRelUser.get(relID)?.get(userID) ?? [userID];
+		};
 
-			const baseCombined = [
-				...existingFlat,
-				...matchedNew.filter((uid) => !existingSet.has(uid))
-			];
-
-			const remainder = baseCombined.length % size;
-			const neededFill = remainder === 0 ? 0 : size - remainder;
-
-			const fillCandidates = (newRosters.get(relID) ?? []).filter(
-				(uid) => !existingSet.has(uid) && !matchedNewSet.has(uid)
-			);
-			const cappedFill = fillCandidates.slice(0, neededFill);
-
-			const combined = [...baseCombined, ...cappedFill];
-			const rebalanced: string[][] = [];
-			for (let i = 0; i < combined.length; i += size) {
-				rebalanced.push(combined.slice(i, i + size));
-			}
-			rebalancedTuplesByRelID.set(relID, rebalanced);
-
+		const effectiveNewRostersByRelID = new Map<string, string[]>();
+		for (const rel of relationships) {
+			const relID = rel.id;
+			const existingMembers = existingMembersByRelID.get(relID) ?? new Set<string>();
+			const finalMembers = finalMembersByRelID.get(relID) ?? new Set<string>();
 			effectiveNewRostersByRelID.set(
 				relID,
-				combined.filter((uid) => !existingSet.has(uid))
+				[...finalMembers].filter((uid) => !existingMembers.has(uid))
 			);
 		}
-
-		// For relationships without incomplete existing tuples, keep matcher output as-is.
-		for (const [relID, roster] of newRosters) {
-			if (!effectiveNewRostersByRelID.has(relID)) {
-				effectiveNewRostersByRelID.set(relID, roster);
-			}
-		}
-
-		// Build tuples only for new-round additions. Existing tuples are not re-sliced.
-		const newTuplesByRelID = new Map<string, string[][]>();
-		for (const [relID, roster] of effectiveNewRostersByRelID) {
-			const size = tupleSizes.get(relID) ?? 2;
-			const tuples: string[][] = [];
-			for (let i = 0; i < roster.length; i += size) {
-				tuples.push(roster.slice(i, i + size));
-			}
-			newTuplesByRelID.set(relID, tuples);
-		}
-
-		/** Returns the tuple for this user in this relationship, preferring preserved existing tuples. */
-		const getUserTuple = (relID: string, userID: string): string[] => {
-			const rebalancedTuples = rebalancedTuplesByRelID.get(relID);
-			if (rebalancedTuples) {
-				return rebalancedTuples.find((t) => t.includes(userID)) ?? [userID];
-			}
-
-			const existingTuple = existingTupleByRelUser.get(relID)?.get(userID);
-			if (existingTuple) return existingTuple;
-
-			const newTuples = newTuplesByRelID.get(relID) ?? [];
-			return newTuples.find((t) => t.includes(userID)) ?? [userID];
-		};
 
 		// Determine which relIDs gained new members this run
 		const changedRelIDs = new Set<string>(

--- a/src/routes/api/relationships/assignRelationships/+server.ts
+++ b/src/routes/api/relationships/assignRelationships/+server.ts
@@ -57,18 +57,19 @@ export const POST: RequestHandler = async (event) => {
 			?.withQueries({ field: 'relationshipSelectorID', op: '==', value: relationshipSelectorID })
 			.read() ?? [];
 
-		// Split into already-assigned participants and new ones needing matching
-		const alreadyAssigned = allAssignments.filter(
-			(a) =>
-				Array.isArray(a.data.assignedRelationships) &&
-				a.data.assignedRelationships.length > 0
-		);
-		const newAssignments = allAssignments.filter(
+		const assignedCount = (a: Docs.RelationshipAssignment): number =>
+			Array.isArray(a.data.assignedRelationships) ? a.data.assignedRelationships.length : 0;
+
+		// Participants who have submitted rankings and still need more assignments.
+		const assignmentsNeedingMatch = allAssignments.filter(
 			(a) =>
 				Array.isArray(a.data.relationshipRankings) &&
 				a.data.relationshipRankings.length > 0 &&
-				(!Array.isArray(a.data.assignedRelationships) || a.data.assignedRelationships.length === 0)
+				assignedCount(a) < relationshipsPerCharacter
 		);
+
+		// Participants with at least one existing assignment (used for existing rosters/tuples).
+		const participantsWithAssignments = allAssignments.filter((a) => assignedCount(a) > 0);
 
 		// No one has submitted rankings at all
 		const anyWithRankings = allAssignments.some(
@@ -79,14 +80,16 @@ export const POST: RequestHandler = async (event) => {
 		}
 
 		// Everyone who submitted rankings is already assigned
-		if (newAssignments.length === 0) {
-			return json({ success: true, assignments: 0, message: 'All participants are already assigned' });
+		if (assignmentsNeedingMatch.length === 0) {
+			return json({ success: true, assignments: 0, message: 'All participants are already fully assigned' });
 		}
+
+		const matchingParticipantIDs = new Set(assignmentsNeedingMatch.map((a) => a.data.userID));
 
 		// ── 4. Build existing roster map from already-assigned docs ────────────
 		// existingRostersByRelID: relID -> set of userIDs already in that relationship
 		const existingRostersByRelID = new Map<string, string[]>();
-		for (const assignment of alreadyAssigned) {
+		for (const assignment of participantsWithAssignments) {
 			for (const ar of assignment.data.assignedRelationships ?? []) {
 				if (!existingRostersByRelID.has(ar.relationshipID)) {
 					existingRostersByRelID.set(ar.relationshipID, []);
@@ -101,7 +104,8 @@ export const POST: RequestHandler = async (event) => {
 		// ── 5. Build existingCandidates for fillTuples ─────────────────────────
 		// For each already-assigned user, collect posts they ranked but were NOT assigned to.
 		const existingCandidates: { applicant: string; post: string; rank: number }[] = [];
-		for (const assignment of alreadyAssigned) {
+		for (const assignment of participantsWithAssignments) {
+			if (matchingParticipantIDs.has(assignment.data.userID)) continue;
 			const assignedRelIDs = new Set(
 				(assignment.data.assignedRelationships ?? []).map((ar) => ar.relationshipID)
 			);
@@ -113,15 +117,18 @@ export const POST: RequestHandler = async (event) => {
 			});
 		}
 
-		// ── 6. Build and run the matcher (new participants only) ────────────────
+		// ── 6. Build and run the matcher (participants who still need assignments) ────────────────
 		const matcher = new CapacitatedRankMaximalMatcher();
 
-		const shuffledNewAssignments = [...newAssignments].sort(() => Math.random() - 0.5);
+		const shuffledAssignmentsNeedingMatch = [...assignmentsNeedingMatch].sort(() => Math.random() - 0.5);
 		const shuffledRelationships = [...relationships].sort(() => Math.random() - 0.5);
 
-		// Add applicant nodes for new participants only
-		for (const assignment of shuffledNewAssignments) {
-			matcher.addNode(assignment.data.userID, false, relationshipsPerCharacter);
+		// Add applicant nodes with per-user remaining capacity.
+		for (const assignment of shuffledAssignmentsNeedingMatch) {
+			const remainingCapacity = Math.max(0, relationshipsPerCharacter - assignedCount(assignment));
+			if (remainingCapacity > 0) {
+				matcher.addNode(assignment.data.userID, false, remainingCapacity);
+			}
 		}
 
 		// Add post nodes with capacity reduced by existing assignments
@@ -140,18 +147,24 @@ export const POST: RequestHandler = async (event) => {
 			}
 		}
 
-		// Add ranked edges from new participants (only to posts that have remaining slots)
-		for (const assignment of shuffledNewAssignments) {
+		// Add ranked edges from participants needing assignments (skip already-assigned relIDs).
+		for (const assignment of shuffledAssignmentsNeedingMatch) {
 			const userID = assignment.data.userID;
 			const rankings: string[] = assignment.data.relationshipRankings ?? [];
+			const existingRelIDs = new Set(
+				(assignment.data.assignedRelationships ?? []).map((ar) => ar.relationshipID)
+			);
 			rankings.forEach((relID, index) => {
-				if (addedPostIDs.has(relID)) {
+				if (addedPostIDs.has(relID) && !existingRelIDs.has(relID)) {
 					matcher.addEdge(userID, relID, index + 1);
 				}
 			});
 		}
 
-		const maxRank = Math.max(...shuffledNewAssignments.map((a) => a.data.relationshipRankings?.length ?? 0), 1);
+		const maxRank = Math.max(
+			...shuffledAssignmentsNeedingMatch.map((a) => a.data.relationshipRankings?.length ?? 0),
+			1
+		);
 
 		const matching = matcher.solve(maxRank);
 		// newRosters: Map<relID, newRoundUserIDs[]> — new-round additions only
@@ -179,7 +192,7 @@ export const POST: RequestHandler = async (event) => {
 		const existingMembersByRelID = new Map<string, Set<string>>();
 		const existingTupleByRelUser = new Map<string, Map<string, string[]>>();
 		const existingTupleKeysByRelID = new Map<string, Set<string>>();
-		for (const assignment of alreadyAssigned) {
+		for (const assignment of participantsWithAssignments) {
 			for (const ar of assignment.data.assignedRelationships ?? []) {
 				if (!existingTuplesByRelID.has(ar.relationshipID)) {
 					existingTuplesByRelID.set(ar.relationshipID, []);
@@ -289,12 +302,12 @@ export const POST: RequestHandler = async (event) => {
 				.map(([relID]) => relID)
 		);
 
-		// Build per-user assignment list for new participants from combined rosters
+		// Build per-user assignment list for participants needing assignments.
 		const newUserAssignments = new Map<string, string[]>();
 		for (const [relID, userIDs] of effectiveNewRostersByRelID) {
 			for (const userID of userIDs) {
-				// Only track new-round users (not existing fill candidates pulled in)
-				if (newAssignments.some((a) => a.data.userID === userID)) {
+				// Only track users this run was trying to (partially) assign.
+				if (matchingParticipantIDs.has(userID)) {
 					if (!newUserAssignments.has(userID)) newUserAssignments.set(userID, []);
 					newUserAssignments.get(userID)!.push(relID);
 				}
@@ -307,21 +320,36 @@ export const POST: RequestHandler = async (event) => {
 		};
 		const ops: WriteOp[] = [];
 
-		// Write docs for new participants
-		for (const assignment of newAssignments) {
+		// Write docs for participants who were matched this run, preserving existing relationships.
+		for (const assignment of assignmentsNeedingMatch) {
 			const userID = assignment.data.userID;
 			const assignedRelIDs = newUserAssignments.get(userID) ?? [];
-			const assignedRelationships = assignedRelIDs.map((relID) => ({
-				relationshipID: relID,
-				assignedUserIDs: getUserTuple(relID, userID),
-				shared: false
-			}));
+			const existingRels = assignment.data.assignedRelationships ?? [];
+			const updatedMap = new Map(existingRels.map((ar) => [ar.relationshipID, ar]));
+
+			for (const relID of assignedRelIDs) {
+				const prev = updatedMap.get(relID);
+				updatedMap.set(relID, {
+					relationshipID: relID,
+					assignedUserIDs: getUserTuple(relID, userID),
+					shared: prev?.shared ?? false
+				});
+			}
+
+			for (const [relID, ar] of updatedMap) {
+				if (changedRelIDs.has(relID)) {
+					updatedMap.set(relID, { ...ar, assignedUserIDs: getUserTuple(relID, userID) });
+				}
+			}
+
+			const assignedRelationships = [...updatedMap.values()];
 			const key = relationshipAssignmentKey(relationshipSelectorID, userID);
 			ops.push({ path: `games/${gameID}/relationshipAssignments/${key}`, data: { assignedRelationships } });
 		}
 
 		// Patch existing participants' docs for any relationship that gained new members
-		for (const assignment of alreadyAssigned) {
+		for (const assignment of participantsWithAssignments) {
+			if (matchingParticipantIDs.has(assignment.data.userID)) continue;
 			const touchedRels = (assignment.data.assignedRelationships ?? []).filter((ar) =>
 				changedRelIDs.has(ar.relationshipID)
 			);
@@ -342,8 +370,8 @@ export const POST: RequestHandler = async (event) => {
 		}
 
 		// Also patch any existing user who was pulled in as a fill candidate this run
-		// (they appear in newRosters but are not in newAssignments)
-		const newParticipantIDs = new Set(newAssignments.map((a) => a.data.userID));
+		// (they appear in newRosters but are not in this run's match target set)
+		const newParticipantIDs = new Set(assignmentsNeedingMatch.map((a) => a.data.userID));
 		const fillFromExisting = new Map<string, string[]>(); // userID -> relIDs they were fill-added to
 		for (const [relID, userIDs] of effectiveNewRostersByRelID) {
 			for (const userID of userIDs) {
@@ -355,7 +383,7 @@ export const POST: RequestHandler = async (event) => {
 			}
 		}
 		for (const [userID, addedRelIDs] of fillFromExisting) {
-			const existingDoc = alreadyAssigned.find((a) => a.data.userID === userID);
+			const existingDoc = participantsWithAssignments.find((a) => a.data.userID === userID);
 			if (!existingDoc) continue; // shouldn't happen
 			const existingRels = existingDoc.data.assignedRelationships ?? [];
 			// Merge: update changed rels + append newly fill-added rels
@@ -391,7 +419,7 @@ export const POST: RequestHandler = async (event) => {
 			await batch.commit();
 		}
 
-		return json({ success: true, assignments: newAssignments.length });
+		return json({ success: true, assignments: assignmentsNeedingMatch.length });
 	} catch (err: any) {
 		console.error('assignRelationships error:', err);
 		return json({ success: false, message: (err as Error).message ?? String(err) });

--- a/src/routes/api/relationships/assignRelationships/+server.ts
+++ b/src/routes/api/relationships/assignRelationships/+server.ts
@@ -158,30 +158,83 @@ export const POST: RequestHandler = async (event) => {
 		const newRosters = matcher.fillTuples(matching, tupleSizes, existingCandidates);
 
 		// ── 7. Write results to Firestore via batched writes ────────────────────
-		// Build combined rosters: existing members + new-round additions per relID
-		const combinedRosters = new Map<string, string[]>();
-		for (const rel of relationships) {
-			const existing = existingRostersByRelID.get(rel.id) ?? [];
-			const added = newRosters.get(rel.id) ?? [];
-			combinedRosters.set(rel.id, [...existing, ...added]);
+		// Preserve existing tuple memberships exactly as stored, keyed by rel/user.
+		const existingTupleByRelUser = new Map<string, Map<string, string[]>>();
+		const existingTuplesByRelID = new Map<string, string[][]>();
+		for (const assignment of alreadyAssigned) {
+			for (const ar of assignment.data.assignedRelationships ?? []) {
+				if (!existingTupleByRelUser.has(ar.relationshipID)) {
+					existingTupleByRelUser.set(ar.relationshipID, new Map());
+				}
+				if (!existingTuplesByRelID.has(ar.relationshipID)) {
+					existingTuplesByRelID.set(ar.relationshipID, []);
+				}
+				const byUser = existingTupleByRelUser.get(ar.relationshipID)!;
+				const tuple = Array.isArray(ar.assignedUserIDs) && ar.assignedUserIDs.length > 0
+					? ar.assignedUserIDs
+					: [assignment.data.userID];
+				const tuples = existingTuplesByRelID.get(ar.relationshipID)!;
+				const tupleKey = [...tuple].sort().join('|');
+				if (!tuples.some((t) => [...t].sort().join('|') === tupleKey)) {
+					tuples.push(tuple);
+				}
+				for (const uid of tuple) {
+					byUser.set(uid, tuple);
+				}
+			}
 		}
 
-		// Partition each relationship's combined roster into tuples so each user
-		// stores only their specific group, not the entire roster.
-		const tuplesByRelID = new Map<string, string[][]>();
-		for (const [relID, roster] of combinedRosters) {
+		// If a relationship already has incomplete tuples, rebalance that relationship
+		// with new-round additions so incomplete groups can be completed.
+		const rebalancedTuplesByRelID = new Map<string, string[][]>();
+		for (const [relID, tuples] of existingTuplesByRelID) {
+			const size = tupleSizes.get(relID) ?? 2;
+			const hasIncomplete = tuples.some((t) => t.length < size);
+			if (!hasIncomplete) continue;
+
+			const seen = new Set<string>();
+			const existingFlat: string[] = [];
+			for (const tuple of tuples) {
+				for (const uid of tuple) {
+					if (!seen.has(uid)) {
+						seen.add(uid);
+						existingFlat.push(uid);
+					}
+				}
+			}
+
+			const added = newRosters.get(relID) ?? [];
+			const combined = [...existingFlat, ...added.filter((uid) => !seen.has(uid))];
+			const rebalanced: string[][] = [];
+			for (let i = 0; i < combined.length; i += size) {
+				rebalanced.push(combined.slice(i, i + size));
+			}
+			rebalancedTuplesByRelID.set(relID, rebalanced);
+		}
+
+		// Build tuples only for new-round additions. Existing tuples are not re-sliced.
+		const newTuplesByRelID = new Map<string, string[][]>();
+		for (const [relID, roster] of newRosters) {
 			const size = tupleSizes.get(relID) ?? 2;
 			const tuples: string[][] = [];
 			for (let i = 0; i < roster.length; i += size) {
 				tuples.push(roster.slice(i, i + size));
 			}
-			tuplesByRelID.set(relID, tuples);
+			newTuplesByRelID.set(relID, tuples);
 		}
 
-		/** Returns the specific tuple within a relationship that contains this user. */
+		/** Returns the tuple for this user in this relationship, preferring preserved existing tuples. */
 		const getUserTuple = (relID: string, userID: string): string[] => {
-			const tuples = tuplesByRelID.get(relID) ?? [];
-			return tuples.find((t) => t.includes(userID)) ?? [userID];
+			const rebalancedTuples = rebalancedTuplesByRelID.get(relID);
+			if (rebalancedTuples) {
+				return rebalancedTuples.find((t) => t.includes(userID)) ?? [userID];
+			}
+
+			const existingTuple = existingTupleByRelUser.get(relID)?.get(userID);
+			if (existingTuple) return existingTuple;
+
+			const newTuples = newTuplesByRelID.get(relID) ?? [];
+			return newTuples.find((t) => t.includes(userID)) ?? [userID];
 		};
 
 		// Determine which relIDs gained new members this run

--- a/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
+++ b/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
@@ -705,4 +705,255 @@ describe('POST /api/relationships/assignRelationships', () => {
       read: vi.fn(async () => relationships.find((r) => r.id === id))
     }) as any);
   });
+
+  it('preserves existing complete tuples when rerunning for unmatched participants', async () => {
+    const stableSelectorID = 'stable-tuples-selector';
+    const stableRelID = 'stable-rel';
+
+    const stableSelector = makeDoc(stableSelectorID, {
+      name: 'Stable Tuples Selector',
+      relationshipIDs: [stableRelID],
+      relationshipsPerCharacter: 1
+    });
+
+    const stableRelationship = makeDoc(stableRelID, {
+      name: 'Stable Relationship',
+      capacity: 0,
+      size: 2,
+      type: '',
+      fields: {}
+    });
+
+    const { database } = await import('$lib/database');
+    vi.mocked(database.relationshipSelectors!.doc).mockReturnValueOnce({
+      read: vi.fn(async () => stableSelector)
+    } as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => (id === stableRelID ? stableRelationship : undefined))
+    }) as any);
+
+    // Existing complete tuples are [e1, e3] and [e2, e4].
+    // The docs are intentionally ordered by user so rebuilding tuples from a flat
+    // roster would produce [e1, e2] and [e3, e4], which would rewrite the
+    // original connections.
+    const existingDocs = [
+      makeDoc(`${stableSelectorID}-e1`, {
+        userID: 'e1',
+        relationshipSelectorID: stableSelectorID,
+        relationshipRankings: [stableRelID],
+        assignedRelationships: [{ relationshipID: stableRelID, assignedUserIDs: ['e1', 'e3'] }]
+      }),
+      makeDoc(`${stableSelectorID}-e2`, {
+        userID: 'e2',
+        relationshipSelectorID: stableSelectorID,
+        relationshipRankings: [stableRelID],
+        assignedRelationships: [{ relationshipID: stableRelID, assignedUserIDs: ['e2', 'e4'] }]
+      }),
+      makeDoc(`${stableSelectorID}-e3`, {
+        userID: 'e3',
+        relationshipSelectorID: stableSelectorID,
+        relationshipRankings: [stableRelID],
+        assignedRelationships: [{ relationshipID: stableRelID, assignedUserIDs: ['e1', 'e3'] }]
+      }),
+      makeDoc(`${stableSelectorID}-e4`, {
+        userID: 'e4',
+        relationshipSelectorID: stableSelectorID,
+        relationshipRankings: [stableRelID],
+        assignedRelationships: [{ relationshipID: stableRelID, assignedUserIDs: ['e2', 'e4'] }]
+      })
+    ];
+
+    const newDocs = [
+      makeDoc(`${stableSelectorID}-n1`, {
+        userID: 'n1',
+        relationshipSelectorID: stableSelectorID,
+        relationshipRankings: [stableRelID],
+        assignedRelationships: []
+      }),
+      makeDoc(`${stableSelectorID}-n2`, {
+        userID: 'n2',
+        relationshipSelectorID: stableSelectorID,
+        relationshipRankings: [stableRelID],
+        assignedRelationships: []
+      })
+    ];
+
+    assignmentDocs = [...existingDocs, ...newDocs];
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: stableSelectorID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const e1Op = batchOps.find((op) => op.path.includes(`${stableSelectorID}-e1`));
+    const e2Op = batchOps.find((op) => op.path.includes(`${stableSelectorID}-e2`));
+    const e3Op = batchOps.find((op) => op.path.includes(`${stableSelectorID}-e3`));
+    const e4Op = batchOps.find((op) => op.path.includes(`${stableSelectorID}-e4`));
+
+    expect(e1Op).toBeDefined();
+    expect(e2Op).toBeDefined();
+    expect(e3Op).toBeDefined();
+    expect(e4Op).toBeDefined();
+
+    const getAssignedUserIDs = (op: { data: unknown }) => {
+      const rels = (op.data as { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] })
+        .assignedRelationships;
+      return rels.find((ar) => ar.relationshipID === stableRelID)?.assignedUserIDs ?? [];
+    };
+
+    expect(getAssignedUserIDs(e1Op!)).toEqual(['e1', 'e3']);
+    expect(getAssignedUserIDs(e3Op!)).toEqual(['e1', 'e3']);
+    expect(getAssignedUserIDs(e2Op!)).toEqual(['e2', 'e4']);
+    expect(getAssignedUserIDs(e4Op!)).toEqual(['e2', 'e4']);
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
+
+  it('production-shape rerun preserves existing tuples and only adds new relationships', async () => {
+    const PROD_SELECTOR_ID = 'prod-shape-selector';
+    const INITIAL_USERS = 99;
+    const ADDED_USERS = 6;
+    const REL_COUNT = 14;
+    const relIDs = Array.from({ length: REL_COUNT }, (_, i) => `prod-rel-${i}`);
+
+    const prodSelector = makeDoc(PROD_SELECTOR_ID, {
+      name: 'Production Shape Selector',
+      relationshipIDs: relIDs,
+      relationshipsPerCharacter: 2
+    });
+
+    const prodRelationships = relIDs.map((id, i) =>
+      makeDoc(id, {
+        name: `Prod Relationship ${i}`,
+        capacity: 0,
+        size: i < 12 ? 2 : 3,
+        type: '',
+        fields: {}
+      })
+    );
+
+    const { database } = await import('$lib/database');
+    vi.mocked(database.relationshipSelectors!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => (id === PROD_SELECTOR_ID ? prodSelector : selectorDoc))
+    }) as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => prodRelationships.find((r) => r.id === id) ?? relationships.find((r) => r.id === id))
+    }) as any);
+
+    const rotatedRankings = (offset: number) => {
+      const shifted = [...relIDs.slice(offset), ...relIDs.slice(0, offset)];
+      return shifted;
+    };
+
+    const initialDocs = Array.from({ length: INITIAL_USERS }, (_, i) => {
+      const uid = `prod-user-${i}`;
+      return makeDoc(`${PROD_SELECTOR_ID}-${uid}`, {
+        userID: uid,
+        relationshipSelectorID: PROD_SELECTOR_ID,
+        relationshipRankings: rotatedRankings(i % relIDs.length),
+        assignedRelationships: []
+      });
+    });
+
+    assignmentDocs = initialDocs;
+
+    const applyBatchOpsToAssignmentDocs = () => {
+      const byDocID = new Map(assignmentDocs.map((d) => [d.id, d]));
+      for (const op of batchOps) {
+        const docID = op.path.split('/').pop()!;
+        const payload = op.data as { assignedRelationships?: any[] };
+        const existing = byDocID.get(docID);
+        if (existing) {
+          existing.data = {
+            ...existing.data,
+            ...(payload.assignedRelationships ? { assignedRelationships: payload.assignedRelationships } : {})
+          };
+        } else {
+          const userID = docID.replace(`${PROD_SELECTOR_ID}-`, '');
+          const created = makeDoc(docID, {
+            userID,
+            relationshipSelectorID: PROD_SELECTOR_ID,
+            relationshipRankings: [],
+            assignedRelationships: payload.assignedRelationships ?? []
+          });
+          assignmentDocs.push(created as any);
+          byDocID.set(docID, created as any);
+        }
+      }
+    };
+
+    const getRelMap = (doc: any): Record<string, string[]> => {
+      const rels = doc.data.assignedRelationships ?? [];
+      const out: Record<string, string[]> = {};
+      for (const rel of rels) {
+        out[rel.relationshipID] = [...(rel.assignedUserIDs ?? [])].sort();
+      }
+      return out;
+    };
+
+    // 1) First run
+    let res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: PROD_SELECTOR_ID }));
+    let body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignments).toBe(INITIAL_USERS);
+    applyBatchOpsToAssignmentDocs();
+
+    const baselineByUser = new Map<string, Record<string, string[]>>();
+    for (const d of assignmentDocs) {
+      if (!d.data.userID.startsWith('prod-user-')) continue;
+      baselineByUser.set(d.data.userID, getRelMap(d));
+    }
+
+    // 2) Add 6 new participants
+    const addedDocs = Array.from({ length: ADDED_USERS }, (_, i) => {
+      const uid = `prod-new-${i}`;
+      return makeDoc(`${PROD_SELECTOR_ID}-${uid}`, {
+        userID: uid,
+        relationshipSelectorID: PROD_SELECTOR_ID,
+        relationshipRankings: rotatedRankings((i * 3) % relIDs.length),
+        assignedRelationships: []
+      });
+    });
+    assignmentDocs = [...assignmentDocs, ...addedDocs];
+
+    batchOps = [];
+    batchCommitCount = 0;
+
+    // 3) Rerun for unmatched participants
+    res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: PROD_SELECTOR_ID }));
+    body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignments).toBe(ADDED_USERS);
+    applyBatchOpsToAssignmentDocs();
+
+    // Existing users: pre-existing relationships must stay exactly the same tuple members.
+    // They may gain additional relationships due to fill behavior.
+    for (const d of assignmentDocs) {
+      const uid = d.data.userID;
+      if (!uid.startsWith('prod-user-')) continue;
+      const before = baselineByUser.get(uid)!;
+      const after = getRelMap(d);
+
+      for (const [relID, beforeTuple] of Object.entries(before)) {
+        expect(after[relID]).toBeDefined();
+        expect(after[relID]).toEqual(beforeTuple);
+      }
+    }
+
+    // New users should now have assignment data.
+    for (const d of assignmentDocs.filter((x) => x.data.userID.startsWith('prod-new-'))) {
+      expect(Array.isArray(d.data.assignedRelationships)).toBe(true);
+      expect(d.data.assignedRelationships.length).toBeGreaterThan(0);
+    }
+
+    // Restore
+    vi.mocked(database.relationshipSelectors!.doc).mockImplementation(() => ({
+      read: vi.fn(async () => selectorDoc)
+    }) as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
 });

--- a/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
+++ b/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
@@ -956,4 +956,109 @@ describe('POST /api/relationships/assignRelationships', () => {
       read: vi.fn(async () => relationships.find((r) => r.id === id))
     }) as any);
   });
+
+  it('does not create a new orphan tuple when a new participant fills an existing orphan', async () => {
+    const ORPHAN_SELECTOR_ID = 'orphan-rebalance-selector';
+    const relA = 'rel-a';
+    const relB = 'rel-b';
+
+    const orphanSelector = makeDoc(ORPHAN_SELECTOR_ID, {
+      name: 'Orphan Rebalance Selector',
+      relationshipIDs: [relA, relB],
+      relationshipsPerCharacter: 1
+    });
+
+    const orphanRels = [
+      makeDoc(relA, { name: 'Rel A', capacity: 0, size: 2, type: '', fields: {} }),
+      makeDoc(relB, { name: 'Rel B', capacity: 0, size: 2, type: '', fields: {} })
+    ];
+
+    const { database } = await import('$lib/database');
+    vi.mocked(database.relationshipSelectors!.doc).mockReturnValueOnce({
+      read: vi.fn(async () => orphanSelector)
+    } as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => orphanRels.find((r) => r.id === id))
+    }) as any);
+
+    // Existing state mimics a post-delete orphan on relA:
+    // - e1 is orphaned on relA
+    // - e2/e3 are assigned to relB and both ranked relA as well (eligible fill candidates)
+    const existingDocs = [
+      makeDoc(`${ORPHAN_SELECTOR_ID}-e1`, {
+        userID: 'e1',
+        relationshipSelectorID: ORPHAN_SELECTOR_ID,
+        relationshipRankings: [relA, relB],
+        assignedRelationships: [{ relationshipID: relA, assignedUserIDs: ['e1'] }]
+      }),
+      makeDoc(`${ORPHAN_SELECTOR_ID}-e2`, {
+        userID: 'e2',
+        relationshipSelectorID: ORPHAN_SELECTOR_ID,
+        relationshipRankings: [relA, relB],
+        assignedRelationships: [{ relationshipID: relB, assignedUserIDs: ['e2', 'e3'] }]
+      }),
+      makeDoc(`${ORPHAN_SELECTOR_ID}-e3`, {
+        userID: 'e3',
+        relationshipSelectorID: ORPHAN_SELECTOR_ID,
+        relationshipRankings: [relA, relB],
+        assignedRelationships: [{ relationshipID: relB, assignedUserIDs: ['e2', 'e3'] }]
+      })
+    ];
+
+    const newDoc = makeDoc(`${ORPHAN_SELECTOR_ID}-n1`, {
+      userID: 'n1',
+      relationshipSelectorID: ORPHAN_SELECTOR_ID,
+      relationshipRankings: [relA, relB],
+      assignedRelationships: []
+    });
+
+    assignmentDocs = [...existingDocs, newDoc];
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: ORPHAN_SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignments).toBe(1);
+
+    // Materialize the new assignedRelationships state from batch writes.
+    const finalByUser = new Map<string, { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] }>();
+    for (const d of assignmentDocs) {
+      finalByUser.set(d.data.userID, {
+        assignedRelationships: (d.data.assignedRelationships ?? []).map((ar: any) => ({
+          relationshipID: ar.relationshipID,
+          assignedUserIDs: ar.assignedUserIDs ?? []
+        }))
+      });
+    }
+    for (const op of batchOps) {
+      const docID = op.path.split('/').pop()!;
+      const userID = docID.replace(`${ORPHAN_SELECTOR_ID}-`, '');
+      const payload = op.data as { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] };
+      finalByUser.set(userID, {
+        assignedRelationships: payload.assignedRelationships.map((ar) => ({
+          relationshipID: ar.relationshipID,
+          assignedUserIDs: ar.assignedUserIDs ?? []
+        }))
+      });
+    }
+
+    // After rerun, relA should be fully paired and must not produce a new singleton tuple.
+    // Count unique relA tuples by sorted member set.
+    const relATuples = new Set<string>();
+    for (const [userID, doc] of finalByUser) {
+      const relAEntry = doc.assignedRelationships.find((ar) => ar.relationshipID === relA);
+      if (!relAEntry) continue;
+      // Sanity: each stored tuple should include the doc owner when present.
+      if (relAEntry.assignedUserIDs.includes(userID)) {
+        relATuples.add([...relAEntry.assignedUserIDs].sort().join('|'));
+      }
+    }
+
+    const hasSingletonRelATuple = [...relATuples].some((tupleKey) => tupleKey.split('|').length === 1);
+    expect(hasSingletonRelATuple).toBe(false);
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
 });

--- a/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
+++ b/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
@@ -1061,4 +1061,165 @@ describe('POST /api/relationships/assignRelationships', () => {
       read: vi.fn(async () => relationships.find((r) => r.id === id))
     }) as any);
   });
+
+  it('fills an orphaned middle tuple without reshuffling adjacent complete tuples', async () => {
+    const SELECTOR_ID = 'rivalry-selector';
+    const RIVALRY_ID = 'rivalry';
+
+    const selector = makeDoc(SELECTOR_ID, {
+      name: 'Rivalry Selector',
+      relationshipIDs: [RIVALRY_ID],
+      relationshipsPerCharacter: 1
+    });
+
+    const rivalryRel = makeDoc(RIVALRY_ID, {
+      name: 'Rivalry',
+      capacity: 0,
+      size: 2,
+      type: '',
+      fields: {}
+    });
+
+    const { database } = await import('$lib/database');
+    vi.mocked(database.relationshipSelectors!.doc).mockReturnValueOnce({
+      read: vi.fn(async () => selector)
+    } as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => (id === RIVALRY_ID ? rivalryRel : undefined))
+    }) as any);
+
+    const rel = (members: string[]) => ({ relationshipID: RIVALRY_ID, assignedUserIDs: members });
+
+    // Post-delete state:
+    // Group 1: Bolt, Runtime
+    // Group 2: Cache, Ether
+    // Group 3: Catalyst, Warden
+    // Group 4: Silent, Nexus
+    // Group 5: Phantom          (orphan)
+    // Group 6: Statute, Order
+    //
+    // New participant: Power2 should fill Phantom, not cause Group 6 reshuffle.
+    assignmentDocs = [
+      makeDoc(`${SELECTOR_ID}-Bolt`, { userID: 'Bolt', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Bolt', 'Runtime'])] }),
+      makeDoc(`${SELECTOR_ID}-Runtime`, { userID: 'Runtime', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Bolt', 'Runtime'])] }),
+      makeDoc(`${SELECTOR_ID}-Cache`, { userID: 'Cache', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Cache', 'Ether'])] }),
+      makeDoc(`${SELECTOR_ID}-Ether`, { userID: 'Ether', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Cache', 'Ether'])] }),
+      makeDoc(`${SELECTOR_ID}-Catalyst`, { userID: 'Catalyst', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Catalyst', 'Warden'])] }),
+      makeDoc(`${SELECTOR_ID}-Warden`, { userID: 'Warden', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Catalyst', 'Warden'])] }),
+      makeDoc(`${SELECTOR_ID}-Silent`, { userID: 'Silent', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Silent', 'Nexus'])] }),
+      makeDoc(`${SELECTOR_ID}-Nexus`, { userID: 'Nexus', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Silent', 'Nexus'])] }),
+      makeDoc(`${SELECTOR_ID}-Phantom`, { userID: 'Phantom', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Phantom'])] }),
+      makeDoc(`${SELECTOR_ID}-Statute`, { userID: 'Statute', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Statute', 'Order'])] }),
+      makeDoc(`${SELECTOR_ID}-Order`, { userID: 'Order', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [rel(['Statute', 'Order'])] }),
+      makeDoc(`${SELECTOR_ID}-Power2`, { userID: 'Power2', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [RIVALRY_ID], assignedRelationships: [] })
+    ];
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignments).toBe(1);
+
+    const byUser = new Map<string, string[]>();
+    for (const op of batchOps) {
+      const docID = op.path.split('/').pop()!;
+      const userID = docID.replace(`${SELECTOR_ID}-`, '');
+      const payload = op.data as {
+        assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[];
+      };
+      const rivalry = payload.assignedRelationships.find((a) => a.relationshipID === RIVALRY_ID);
+      if (rivalry) byUser.set(userID, rivalry.assignedUserIDs);
+    }
+
+    // Existing complete tuple must remain intact.
+    expect(byUser.get('Statute')).toEqual(['Statute', 'Order']);
+    expect(byUser.get('Order')).toEqual(['Statute', 'Order']);
+
+    // Orphan must be filled by the new participant.
+    expect(byUser.get('Phantom')).toEqual(['Phantom', 'Power2']);
+    expect(byUser.get('Power2')).toEqual(['Phantom', 'Power2']);
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
+
+  it('fills an orphaned middle 3-tuple without reshuffling adjacent complete 3-tuples', async () => {
+    const SELECTOR_ID = 'trio-selector';
+    const TRIO_REL_ID = 'trio-rel';
+
+    const selector = makeDoc(SELECTOR_ID, {
+      name: 'Trio Selector',
+      relationshipIDs: [TRIO_REL_ID],
+      relationshipsPerCharacter: 1
+    });
+
+    const trioRel = makeDoc(TRIO_REL_ID, {
+      name: 'Trio Relationship',
+      capacity: 0,
+      size: 3,
+      type: '',
+      fields: {}
+    });
+
+    const { database } = await import('$lib/database');
+    vi.mocked(database.relationshipSelectors!.doc).mockReturnValueOnce({
+      read: vi.fn(async () => selector)
+    } as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => (id === TRIO_REL_ID ? trioRel : undefined))
+    }) as any);
+
+    const rel = (members: string[]) => ({ relationshipID: TRIO_REL_ID, assignedUserIDs: members });
+
+    // Existing post-delete state:
+    // Group 1: Alpha, Bravo, Charlie
+    // Group 2: Delta, Echo, Foxtrot
+    // Group 3: Gamma, Helix         (orphan size-2 for tuple size 3)
+    // Group 4: Indigo, Joker, Kappa
+    // New participant: Lambda should fill Group 3 without disturbing Group 2/4.
+    assignmentDocs = [
+      makeDoc(`${SELECTOR_ID}-Alpha`, { userID: 'Alpha', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Alpha', 'Bravo', 'Charlie'])] }),
+      makeDoc(`${SELECTOR_ID}-Bravo`, { userID: 'Bravo', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Alpha', 'Bravo', 'Charlie'])] }),
+      makeDoc(`${SELECTOR_ID}-Charlie`, { userID: 'Charlie', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Alpha', 'Bravo', 'Charlie'])] }),
+      makeDoc(`${SELECTOR_ID}-Delta`, { userID: 'Delta', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Delta', 'Echo', 'Foxtrot'])] }),
+      makeDoc(`${SELECTOR_ID}-Echo`, { userID: 'Echo', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Delta', 'Echo', 'Foxtrot'])] }),
+      makeDoc(`${SELECTOR_ID}-Foxtrot`, { userID: 'Foxtrot', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Delta', 'Echo', 'Foxtrot'])] }),
+      makeDoc(`${SELECTOR_ID}-Gamma`, { userID: 'Gamma', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Gamma', 'Helix'])] }),
+      makeDoc(`${SELECTOR_ID}-Helix`, { userID: 'Helix', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Gamma', 'Helix'])] }),
+      makeDoc(`${SELECTOR_ID}-Indigo`, { userID: 'Indigo', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Indigo', 'Joker', 'Kappa'])] }),
+      makeDoc(`${SELECTOR_ID}-Joker`, { userID: 'Joker', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Indigo', 'Joker', 'Kappa'])] }),
+      makeDoc(`${SELECTOR_ID}-Kappa`, { userID: 'Kappa', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [rel(['Indigo', 'Joker', 'Kappa'])] }),
+      makeDoc(`${SELECTOR_ID}-Lambda`, { userID: 'Lambda', relationshipSelectorID: SELECTOR_ID, relationshipRankings: [TRIO_REL_ID], assignedRelationships: [] })
+    ];
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignments).toBe(1);
+
+    const byUser = new Map<string, string[]>();
+    for (const op of batchOps) {
+      const docID = op.path.split('/').pop()!;
+      const userID = docID.replace(`${SELECTOR_ID}-`, '');
+      const payload = op.data as {
+        assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[];
+      };
+      const trio = payload.assignedRelationships.find((a) => a.relationshipID === TRIO_REL_ID);
+      if (trio) byUser.set(userID, trio.assignedUserIDs);
+    }
+
+    expect(byUser.get('Delta')).toEqual(['Delta', 'Echo', 'Foxtrot']);
+    expect(byUser.get('Echo')).toEqual(['Delta', 'Echo', 'Foxtrot']);
+    expect(byUser.get('Foxtrot')).toEqual(['Delta', 'Echo', 'Foxtrot']);
+
+    expect(byUser.get('Gamma')).toEqual(['Gamma', 'Helix', 'Lambda']);
+    expect(byUser.get('Helix')).toEqual(['Gamma', 'Helix', 'Lambda']);
+    expect(byUser.get('Lambda')).toEqual(['Gamma', 'Helix', 'Lambda']);
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
 });

--- a/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
+++ b/src/routes/api/relationships/assignRelationships/__tests__/assignRelationships.spec.ts
@@ -461,14 +461,17 @@ describe('POST /api/relationships/assignRelationships', () => {
 
   // ── Incremental matchmaking ─────────────────────────────────────────────────
 
-  it('returns success with assignments=0 when all participants are already assigned', async () => {
-    // All docs have non-empty assignedRelationships
+  it('returns success with assignments=0 when all participants are already fully assigned', async () => {
+    // All docs are already at relationshipsPerCharacter.
     assignmentDocs = Array.from({ length: 5 }, (_, i) =>
       makeDoc(`${SELECTOR_ID}-user-${i}`, {
         userID: `user-${i}`,
         relationshipSelectorID: SELECTOR_ID,
         relationshipRankings: shuffle([...relationshipIDs]),
-        assignedRelationships: [{ relationshipID: relationshipIDs[0], assignedUserIDs: [`user-${i}`] }]
+        assignedRelationships: [
+          { relationshipID: relationshipIDs[0], assignedUserIDs: [`user-${i}`] },
+          { relationshipID: relationshipIDs[1], assignedUserIDs: [`user-${i}`] }
+        ]
       })
     );
 
@@ -479,18 +482,19 @@ describe('POST /api/relationships/assignRelationships', () => {
     expect(batchOps).toHaveLength(0); // nothing to write
   });
 
-  it('only matchmakes new participants when some are already assigned', async () => {
+  it('only matchmakes new participants when existing participants are already fully assigned', async () => {
     const ASSIGNED_COUNT = 10;
     const NEW_COUNT = 5;
 
-    // 10 already-assigned participants
+    // 10 already-fully-assigned participants (2 relationships each)
     const alreadyAssignedDocs = Array.from({ length: ASSIGNED_COUNT }, (_, i) =>
       makeDoc(`${SELECTOR_ID}-existing-${i}`, {
         userID: `existing-${i}`,
         relationshipSelectorID: SELECTOR_ID,
         relationshipRankings: shuffle([...relationshipIDs]),
         assignedRelationships: [
-          { relationshipID: relationshipIDs[i % NUM_POSTS], assignedUserIDs: [`existing-${i}`, `existing-${(i + 1) % ASSIGNED_COUNT}`] }
+          { relationshipID: relationshipIDs[i % NUM_POSTS], assignedUserIDs: [`existing-${i}`, `existing-${(i + 1) % ASSIGNED_COUNT}`] },
+          { relationshipID: relationshipIDs[(i + 1) % NUM_POSTS], assignedUserIDs: [`existing-${i}`, `existing-${(i + 2) % ASSIGNED_COUNT}`] }
         ]
       })
     );
@@ -527,13 +531,19 @@ describe('POST /api/relationships/assignRelationships', () => {
         userID: 'ea-0',
         relationshipSelectorID: SELECTOR_ID,
         relationshipRankings: [fullRelID, ...relationshipIDs.filter((r) => r !== fullRelID)],
-        assignedRelationships: [{ relationshipID: fullRelID, assignedUserIDs: ['ea-0', 'ea-1'] }]
+        assignedRelationships: [
+          { relationshipID: fullRelID, assignedUserIDs: ['ea-0', 'ea-1'] },
+          { relationshipID: 'rel-1', assignedUserIDs: ['ea-0', 'ea-1'] }
+        ]
       }),
       makeDoc(`${SELECTOR_ID}-ea-1`, {
         userID: 'ea-1',
         relationshipSelectorID: SELECTOR_ID,
         relationshipRankings: [fullRelID, ...relationshipIDs.filter((r) => r !== fullRelID)],
-        assignedRelationships: [{ relationshipID: fullRelID, assignedUserIDs: ['ea-0', 'ea-1'] }]
+        assignedRelationships: [
+          { relationshipID: fullRelID, assignedUserIDs: ['ea-0', 'ea-1'] },
+          { relationshipID: 'rel-1', assignedUserIDs: ['ea-0', 'ea-1'] }
+        ]
       })
     ];
 
@@ -585,7 +595,8 @@ describe('POST /api/relationships/assignRelationships', () => {
       // force it via alreadyAssigned: they *are* assigned to it already)
       relationshipRankings: [sharedRelID, ...relationshipIDs.slice(1)],
       assignedRelationships: [
-        { relationshipID: sharedRelID, assignedUserIDs: ['e1'] } // incomplete tuple
+        { relationshipID: sharedRelID, assignedUserIDs: ['e1'] }, // incomplete tuple
+        { relationshipID: relationshipIDs[1], assignedUserIDs: ['e1', 'e2'] }
       ]
     });
 
@@ -699,6 +710,55 @@ describe('POST /api/relationships/assignRelationships', () => {
     expect(e1Rel1).toBeDefined();
     expect(e1Rel1!.assignedUserIDs).toContain('n1-fill');
     expect(e1Rel1!.assignedUserIDs).toContain('e1-fill');
+
+    // Restore
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => relationships.find((r) => r.id === id))
+    }) as any);
+  });
+
+  it('treats partially-assigned participants as unmatched and tops them up without dropping existing relationships', async () => {
+    const PARTIAL_SELECTOR_ID = 'partial-selector';
+
+    const partialSelector = makeDoc(PARTIAL_SELECTOR_ID, {
+      name: 'Partial Selector',
+      relationshipIDs: ['rel-a', 'rel-b'],
+      relationshipsPerCharacter: 2
+    });
+
+    const partialRels = [
+      makeDoc('rel-a', { name: 'Rel A', capacity: 10, size: 1, type: '', fields: {} }),
+      makeDoc('rel-b', { name: 'Rel B', capacity: 10, size: 1, type: '', fields: {} })
+    ];
+
+    const { database } = await import('$lib/database');
+    vi.mocked(database.relationshipSelectors!.doc).mockReturnValueOnce({
+      read: vi.fn(async () => partialSelector)
+    } as any);
+    vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
+      read: vi.fn(async () => partialRels.find((r) => r.id === id))
+    }) as any);
+
+    assignmentDocs = [
+      makeDoc(`${PARTIAL_SELECTOR_ID}-user-1`, {
+        userID: 'user-1',
+        relationshipSelectorID: PARTIAL_SELECTOR_ID,
+        relationshipRankings: ['rel-a', 'rel-b'],
+        assignedRelationships: [{ relationshipID: 'rel-a', assignedUserIDs: ['user-1'], shared: false }]
+      })
+    ];
+
+    const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: PARTIAL_SELECTOR_ID }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.assignments).toBe(1);
+
+    const userOp = batchOps.find((op) => op.path.includes(`${PARTIAL_SELECTOR_ID}-user-1`));
+    expect(userOp).toBeDefined();
+    const written = (userOp!.data as { assignedRelationships: { relationshipID: string }[] }).assignedRelationships;
+    const relIDs = written.map((r) => r.relationshipID);
+    expect(relIDs).toContain('rel-a');
+    expect(relIDs).toContain('rel-b');
 
     // Restore
     vi.mocked(database.relationships!.doc).mockImplementation((id: string) => ({
@@ -866,8 +926,9 @@ describe('POST /api/relationships/assignRelationships', () => {
         const payload = op.data as { assignedRelationships?: any[] };
         const existing = byDocID.get(docID);
         if (existing) {
+          const existingData = (existing as any).data ?? {};
           existing.data = {
-            ...existing.data,
+            ...existingData,
             ...(payload.assignedRelationships ? { assignedRelationships: payload.assignedRelationships } : {})
           };
         } else {
@@ -902,8 +963,9 @@ describe('POST /api/relationships/assignRelationships', () => {
 
     const baselineByUser = new Map<string, Record<string, string[]>>();
     for (const d of assignmentDocs) {
-      if (!d.data.userID.startsWith('prod-user-')) continue;
-      baselineByUser.set(d.data.userID, getRelMap(d));
+      const data = (d as any).data;
+      if (!data.userID.startsWith('prod-user-')) continue;
+      baselineByUser.set(data.userID, getRelMap(d));
     }
 
     // 2) Add 6 new participants
@@ -931,7 +993,7 @@ describe('POST /api/relationships/assignRelationships', () => {
     // Existing users: pre-existing relationships must stay exactly the same tuple members.
     // They may gain additional relationships due to fill behavior.
     for (const d of assignmentDocs) {
-      const uid = d.data.userID;
+      const uid = (d as any).data.userID;
       if (!uid.startsWith('prod-user-')) continue;
       const before = baselineByUser.get(uid)!;
       const after = getRelMap(d);
@@ -943,9 +1005,10 @@ describe('POST /api/relationships/assignRelationships', () => {
     }
 
     // New users should now have assignment data.
-    for (const d of assignmentDocs.filter((x) => x.data.userID.startsWith('prod-new-'))) {
-      expect(Array.isArray(d.data.assignedRelationships)).toBe(true);
-      expect(d.data.assignedRelationships.length).toBeGreaterThan(0);
+    for (const d of assignmentDocs.filter((x) => (x as any).data.userID.startsWith('prod-new-'))) {
+      const data = (d as any).data;
+      expect(Array.isArray(data.assignedRelationships)).toBe(true);
+      expect(data.assignedRelationships.length).toBeGreaterThan(0);
     }
 
     // Restore
@@ -1022,8 +1085,9 @@ describe('POST /api/relationships/assignRelationships', () => {
     // Materialize the new assignedRelationships state from batch writes.
     const finalByUser = new Map<string, { assignedRelationships: { relationshipID: string; assignedUserIDs: string[] }[] }>();
     for (const d of assignmentDocs) {
-      finalByUser.set(d.data.userID, {
-        assignedRelationships: (d.data.assignedRelationships ?? []).map((ar: any) => ({
+      const data = (d as any).data;
+      finalByUser.set(data.userID, {
+        assignedRelationships: (data.assignedRelationships ?? []).map((ar: any) => ({
           relationshipID: ar.relationshipID,
           assignedUserIDs: ar.assignedUserIDs ?? []
         }))

--- a/src/routes/api/relationships/deleteAssignedGroup/+server.ts
+++ b/src/routes/api/relationships/deleteAssignedGroup/+server.ts
@@ -1,0 +1,71 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { database, setGameID } from '$lib/database';
+import { isEditor } from '$lib/permissions';
+import type { Docs } from '$lib/database/types';
+
+const tupleKey = (userIDs: string[]): string => [...userIDs].sort().join('|');
+
+/**
+ * POST /api/relationships/deleteAssignedGroup
+ *
+ * Deletes exactly one assigned relationship group (tuple) for a given
+ * relationshipSelector + relationship. Only the assignment entry matching
+ * both relationshipID and assignedUserIDs tuple is removed.
+ *
+ * Body: {
+ *   gameID: string,
+ *   relationshipSelectorID: string,
+ *   relationshipID: string,
+ *   tupleUserIDs: string[]
+ * }
+ */
+export const POST: RequestHandler = async (event) => {
+	const payload = await event.request.json();
+	const gameID: string = payload.gameID || '';
+	const relationshipSelectorID: string = payload.relationshipSelectorID || '';
+	const relationshipID: string = payload.relationshipID || '';
+	const tupleUserIDs: string[] = Array.isArray(payload.tupleUserIDs) ? payload.tupleUserIDs : [];
+
+	if (!event.locals.decodedToken) {
+		return json({ success: false, message: 'Not authenticated' });
+	}
+	if (!gameID || !relationshipSelectorID || !relationshipID || tupleUserIDs.length === 0) {
+		return json({ success: false, message: 'Missing gameID, relationshipSelectorID, relationshipID, or tupleUserIDs' });
+	}
+	if (!isEditor(event.locals.user.roles, gameID)) {
+		return json({ success: false, message: 'Insufficient permissions' });
+	}
+
+	try {
+		setGameID(gameID);
+		const targetKey = tupleKey(tupleUserIDs);
+		const tupleUserSet = new Set(tupleUserIDs);
+
+		const allAssignments: Docs.RelationshipAssignment[] =
+			await database.relationshipAssignments
+				?.withQueries({ field: 'relationshipSelectorID', op: '==', value: relationshipSelectorID })
+				.read() ?? [];
+
+		const docsToUpdate = allAssignments.filter((assignment) => {
+			if (!tupleUserSet.has(assignment.data.userID)) return false;
+			const rels = assignment.data.assignedRelationships ?? [];
+			return rels.some(
+				(rel) => rel.relationshipID === relationshipID && tupleKey(rel.assignedUserIDs ?? []) === targetKey
+			);
+		});
+
+		await Promise.all(
+			docsToUpdate.map(async (assignment) => {
+				const next = (assignment.data.assignedRelationships ?? []).filter(
+					(rel) => !(rel.relationshipID === relationshipID && tupleKey(rel.assignedUserIDs ?? []) === targetKey)
+				);
+				await database.relationshipAssignments?.doc(assignment.id)?.update({ assignedRelationships: next });
+			})
+		);
+
+		return json({ success: true, updated: docsToUpdate.length });
+	} catch (err: any) {
+		console.error('deleteAssignedGroup error:', err);
+		return json({ success: false, message: (err as Error).message ?? String(err) });
+	}
+};

--- a/src/routes/api/relationships/deleteAssignedGroup/__tests__/deleteAssignedGroup.spec.ts
+++ b/src/routes/api/relationships/deleteAssignedGroup/__tests__/deleteAssignedGroup.spec.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '../+server';
+
+function makeDoc<T>(id: string, data: T, exists = true) {
+	return { id, data, exists, update: vi.fn().mockResolvedValue(undefined) };
+}
+
+function makeEvent(body: object, overrides: { decodedToken?: unknown; user?: unknown } = {}) {
+	return {
+		request: { json: vi.fn(async () => body) },
+		locals: {
+			decodedToken: 'decodedToken' in overrides ? overrides.decodedToken : { uid: 'admin-uid' },
+			user: overrides.user ?? { roles: { system: 4 } }
+		}
+	} as any;
+}
+
+const GAME_ID = 'game-test';
+const SELECTOR_ID = 'selector-1';
+const REL_ID = 'rivalry';
+const GROUP_A = ['bob', 'steve'];
+const GROUP_B = ['karen', 'sarah'];
+
+const makeAssignmentDocs = () => [
+	makeDoc('doc-bob', {
+		userID: 'bob',
+		relationshipSelectorID: SELECTOR_ID,
+		relationshipRankings: ['rivalry'],
+		assignedRelationships: [{ relationshipID: REL_ID, assignedUserIDs: GROUP_A, shared: false }]
+	}),
+	makeDoc('doc-steve', {
+		userID: 'steve',
+		relationshipSelectorID: SELECTOR_ID,
+		relationshipRankings: ['rivalry'],
+		assignedRelationships: [{ relationshipID: REL_ID, assignedUserIDs: GROUP_A, shared: false }]
+	}),
+	makeDoc('doc-karen', {
+		userID: 'karen',
+		relationshipSelectorID: SELECTOR_ID,
+		relationshipRankings: ['rivalry'],
+		assignedRelationships: [{ relationshipID: REL_ID, assignedUserIDs: GROUP_B, shared: false }]
+	}),
+	makeDoc('doc-sarah', {
+		userID: 'sarah',
+		relationshipSelectorID: SELECTOR_ID,
+		relationshipRankings: ['rivalry'],
+		assignedRelationships: [{ relationshipID: REL_ID, assignedUserIDs: GROUP_B, shared: false }]
+	}),
+	makeDoc('doc-other', {
+		userID: 'other',
+		relationshipSelectorID: SELECTOR_ID,
+		relationshipRankings: ['rivalry'],
+		assignedRelationships: [{ relationshipID: REL_ID, assignedUserIDs: ['other', 'x'], shared: false }]
+	})
+];
+
+let assignmentDocs: ReturnType<typeof makeDoc>[];
+
+vi.mock('$lib/permissions', () => ({
+	isEditor: vi.fn().mockReturnValue(true)
+}));
+
+vi.mock('$lib/database', () => {
+	const setGameID = vi.fn();
+	const database = {
+		relationshipAssignments: {
+			withQueries: vi.fn(() => ({
+				read: vi.fn(async () => assignmentDocs)
+			})),
+			doc: vi.fn((id: string) =>
+				assignmentDocs.find((d) => d.id === id) ?? { update: vi.fn().mockResolvedValue(undefined) }
+			)
+		}
+	};
+	return { database, setGameID };
+});
+
+describe('POST /api/relationships/deleteAssignedGroup', () => {
+	beforeEach(async () => {
+		assignmentDocs = makeAssignmentDocs();
+		vi.clearAllMocks();
+		vi.mocked((await import('$lib/permissions')).isEditor).mockReturnValue(true);
+	});
+
+	it('returns error when not authenticated', async () => {
+		const res = await POST(
+			makeEvent(
+				{
+					gameID: GAME_ID,
+					relationshipSelectorID: SELECTOR_ID,
+					relationshipID: REL_ID,
+					tupleUserIDs: GROUP_A
+				},
+				{ decodedToken: null }
+			)
+		);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+		expect(body.message).toMatch(/not authenticated/i);
+	});
+
+	it('returns error when fields are missing', async () => {
+		const res = await POST(makeEvent({ gameID: GAME_ID, relationshipSelectorID: SELECTOR_ID }));
+		const body = await res.json();
+		expect(body.success).toBe(false);
+		expect(body.message).toMatch(/missing/i);
+	});
+
+	it('returns error when not an editor', async () => {
+		const { isEditor } = await import('$lib/permissions');
+		vi.mocked(isEditor).mockReturnValueOnce(false);
+		const res = await POST(
+			makeEvent({
+				gameID: GAME_ID,
+				relationshipSelectorID: SELECTOR_ID,
+				relationshipID: REL_ID,
+				tupleUserIDs: GROUP_A
+			})
+		);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+		expect(body.message).toMatch(/permission/i);
+	});
+
+	it('deletes only the targeted group and keeps other groups intact', async () => {
+		const res = await POST(
+			makeEvent({
+				gameID: GAME_ID,
+				relationshipSelectorID: SELECTOR_ID,
+				relationshipID: REL_ID,
+				tupleUserIDs: GROUP_A
+			})
+		);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+		expect(body.updated).toBe(2);
+
+		const bob = assignmentDocs.find((d) => d.id === 'doc-bob')!;
+		const steve = assignmentDocs.find((d) => d.id === 'doc-steve')!;
+		const karen = assignmentDocs.find((d) => d.id === 'doc-karen')!;
+		const sarah = assignmentDocs.find((d) => d.id === 'doc-sarah')!;
+		const other = assignmentDocs.find((d) => d.id === 'doc-other')!;
+
+		expect(bob.update).toHaveBeenCalledOnce();
+		expect(steve.update).toHaveBeenCalledOnce();
+		expect(karen.update).not.toHaveBeenCalled();
+		expect(sarah.update).not.toHaveBeenCalled();
+		expect(other.update).not.toHaveBeenCalled();
+
+		const bobPayload = bob.update.mock.calls[0][0] as Record<string, unknown>;
+		const stevePayload = steve.update.mock.calls[0][0] as Record<string, unknown>;
+		expect(Object.keys(bobPayload)).toEqual(['assignedRelationships']);
+		expect(Object.keys(stevePayload)).toEqual(['assignedRelationships']);
+		expect((bobPayload.assignedRelationships as unknown[]).length).toBe(0);
+		expect((stevePayload.assignedRelationships as unknown[]).length).toBe(0);
+	});
+});


### PR DESCRIPTION
This PR addresses several critical, overlapping bugs:

- Clicking "Run for new participants" will no longer scramble all existing relationship assignments. Relationship assignments are now preserved.
- Clicking "Run for new participants" will no longer ignore "orphaned" relationship assignments. (For example, if a a character is paired with a character that was deleted, they are orphaned and have a relationship assignment but there's no other characters paired with them.) The algorithm will now use these orphaned relationship assignments before creating any new ones.
- Running matchmaking (for both new participants as well as just new participants) will no longer create unmatched pairs, e.g., 13 people assigned to a two-person relationship. The algorithm will now make sure that it only pulls in extra people to balance the tuples if it actually needs to, after accounting for orphaned assignments as well as all new participants.
- Characters with fewer relationship assignments than expected now cause the "Run for new participants" button to appear. Previously, only characters with zero relationship assignments caused the button to appear.

A number of new tests have been written to recreate the bugs described above. Bug fixes now cause these tests to pass. 

Additionally, two new features have been added, to give editors more ability to manually intervene:

- A delete button now exists for individual relationship groups. This will delete the relationship entirely for all the characters involved. Their ranked choices are preserved. 
- An add button now exists for each relationship within the relationship selector. this allows editors to create a new relationship assignment manually. This starts by selecting the first person in the relationship - after it has been created, people can be added the same way they can now, with the edit capability.


Known issues:
- Regardless of how they are created, new relationship assignments default to unshared. The UI will incorrectly show them as shared until you reload the page.
- The edit/add assignment pop-up shows ALL users in the character creator, not just users who have characters in the larp. Editors should make sure they are selecting the right email address.